### PR TITLE
🔒 Fix unsafe strcpy and add null check in LicensePlate

### DIFF
--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -75,10 +75,13 @@ bool __cdecl LicensePlate::CCustomCarPlateMgr_Initialise()
 
     for (int i = 0; i < ePlateType::TOTAL_SZ; i++)
     {
-        strcpy(m_Plates[i]->name, "carpback\0");
-        RwTextureSetAddressingU(m_Plates[i], rwFILTERMIPNEAREST);
-        RwTextureSetAddressingV(m_Plates[i], rwFILTERMIPNEAREST);
-        RwTextureSetFilterMode(m_Plates[i], rwFILTERLINEAR);
+        if (m_Plates[i])
+        {
+            RwTextureSetName(m_Plates[i], "carpback");
+            RwTextureSetAddressingU(m_Plates[i], rwFILTERMIPNEAREST);
+            RwTextureSetAddressingV(m_Plates[i], rwFILTERMIPNEAREST);
+            RwTextureSetFilterMode(m_Plates[i], rwFILTERLINEAR);
+        }
     }
     pCharsetLockedData = RwRasterLock(RwTextureGetRaster(pCharSetTex), 0, rwRASTERLOCKREAD);
     return pCharsetLockedData != 0;


### PR DESCRIPTION
🎯 **What:** Replaced the unsafe `strcpy` call with the standard RenderWare `RwTextureSetName` function and added a null check for the texture array.

⚠️ **Risk:** The use of `strcpy` could lead to a buffer overflow if the source string were ever changed to something longer than the destination buffer. Additionally, the lack of a null check for `m_Plates[i]` could lead to a crash if a texture fails to load.

🛡️ **Solution:** Used `RwTextureSetName`, which is the safe and idiomatic way to set a texture's name in RenderWare, and added a defensive null check to ensure the texture pointer is valid before use.