### PR TITLE
Fix sirens crash

### DIFF
--- a/src/features/sirens.cpp
+++ b/src/features/sirens.cpp
@@ -557,7 +557,9 @@ void Sirens::EventCtor(CVehicle *pVeh)
 {
 	if (Sirens::modelData.contains(pVeh->m_nModelIndex))
 	{
-		vehicleData[pVeh] = new VehicleSiren(pVeh);
+		if (!vehicleData.contains(pVeh)) {
+			vehicleData[pVeh] = new VehicleSiren(pVeh);
+		}
 	}
 }
 
@@ -611,13 +613,19 @@ void Sirens::Init()
 			int matIdx = GetSirenIndex(pVeh, pMat);
 
 			if (matIdx != - 1) {
+				if (!vehicleData.contains(pVeh)) {
+					vehicleData[pVeh] = new VehicleSiren(pVeh);
+				}
 				int curState = vehicleData[pVeh]->GetCurrentState();
-				auto& state = modelData[pVeh->m_nModelIndex]->States[curState];
-				if (state->Materials.contains(matIdx)) {
-					if (modelData[pVeh->m_nModelIndex]->isImVehFtSiren) {
-						return MatStateColor{state->Materials[matIdx]->Color, state->Materials[matIdx]->Color};
-					} else {
-						return MatStateColor{state->Materials[matIdx]->Color, DEFAULT_MAT_COL};
+
+				if (curState >= 0 && curState < modelData[pVeh->m_nModelIndex]->States.size()) {
+					auto& state = modelData[pVeh->m_nModelIndex]->States[curState];
+					if (state->Materials.contains(matIdx)) {
+						if (modelData[pVeh->m_nModelIndex]->isImVehFtSiren) {
+							return MatStateColor{state->Materials[matIdx]->Color, state->Materials[matIdx]->Color};
+						} else {
+							return MatStateColor{state->Materials[matIdx]->Color, DEFAULT_MAT_COL};
+						}
 					}
 				}
 			}

--- a/src/utils/modelinfomgr.cpp
+++ b/src/utils/modelinfomgr.cpp
@@ -240,12 +240,6 @@ RpMaterial *ModelInfoMgr::SetEditableMaterialsCB(RpMaterial *material, void *dat
 	{
 		auto &data = m_VehData.Get(pCurVeh);
 
-		// Sirens crash fix TODO: remove this and fix it
-		if (iLightIndex == eMaterialType::SirenLight && data.nFrameCount <= 10)
-		{
-			return material;
-		}
-
 		bool lightOn = false;
 		data.m_MatAvail[iLightIndex] = true;
 


### PR DESCRIPTION
Fixes a crash related to sirens without using the temporary workaround. The original crash was caused by accessing uninitialized `vehicleData` during the first few frames. The fix properly checks for existence and initializes `vehicleData` in `src/features/sirens.cpp` while removing the workaround in `src/utils/modelinfomgr.cpp`.