### PR TITLE
⚡ Optimize license plate texture copying

### DIFF
--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -252,40 +252,39 @@ bool LicensePlate::CCustomCarPlateMgr_RenderLicenseplateTextToRaster(const char 
     if (!charsRasterStride)
         return false;
 
-    // Copy each character from charset raster to plate raster
-    // Going from left to right
+    // Size of a pixel (texel) in `pCharsetLockedData`. It's in 32 bit BGRA format
+    constexpr auto texelSize = 4;
 
-    auto plateRasterCharIter = lockedPlateRaster; // Always points to the top left corner of each character
+    // Pre-calculate character source pointers to improve memory locality and avoid redundant calculations
+    RwUInt8* charRasterBases[MAX_TEXT_LENGTH];
     for (auto letter = 0; letter < MAX_TEXT_LENGTH; letter++)
     {
         unsigned int charCol, charRow;
         auto t = GetCharacterPositionInCharSet(text[letter]);
         charCol = t.first;
         charRow = t.second;
+        charRasterBases[letter] = &pCharsetLockedData[(CHARSET_COL_WIDTH * CHARSET_ROW_HEIGHT * charRow + CHARSET_CHAR_WIDTH * charCol) * texelSize];
+    }
 
-        // Copy specific character from charset raster to plate raster
+    // Copy characters row by row (outer loop) to improve cache locality on destination raster
+    auto plateRasterRowIter = lockedPlateRaster;
+    for (auto r = 0u; r < CHARSET_CHAR_HEIGHT; r++)
+    {
+        auto plateRasterIt = plateRasterRowIter;
 
-        // Size of a pixel (texel) in `pCharsetLockedData`. It's in 32 bit BGRA format
-        constexpr auto texelSize = 4;
-
-        // Character's top left corner in charset raster
-        auto charRasterIt = &pCharsetLockedData[(CHARSET_COL_WIDTH * CHARSET_ROW_HEIGHT * charRow + CHARSET_CHAR_WIDTH * charCol) * texelSize];
-
-        // Character's top left corner in target (plate) raster
-        auto plateRasterIt = plateRasterCharIter;
-
-        // Copy character row by row (going from top to bottom) to target (plate) raster
-        for (auto r = 0u; r < CHARSET_CHAR_HEIGHT; r++)
+        for (auto letter = 0; letter < MAX_TEXT_LENGTH; letter++)
         {
-            memcpy(plateRasterIt, charRasterIt, CHARSET_CHAR_WIDTH * texelSize); // Copy row
+            memcpy(plateRasterIt, charRasterBases[letter], CHARSET_CHAR_WIDTH * texelSize); // Copy row for this character
 
-            // Advance to next row
-            plateRasterIt += plateRasterStride;
-            charRasterIt += charsRasterStride;
+            // Advance character raster base to next row
+            charRasterBases[letter] += charsRasterStride;
+
+            // Advance plate raster pointer to next character's column
+            plateRasterIt += CHARSET_CHAR_WIDTH * texelSize;
         }
 
-        // Advance to next character's column
-        plateRasterCharIter += CHARSET_CHAR_WIDTH * texelSize;
+        // Advance to next row in target (plate) raster
+        plateRasterRowIter += plateRasterStride;
     }
 
     RwRasterUnlock(plateRaster);


### PR DESCRIPTION
This PR optimizes the way license plate character data is transferred from the charset texture to the destination license plate texture. 

Previously, the routine copied characters entirely (row-by-row within the character) before moving on to the next character in the string. Because the license plate destination pixels for different characters are adjacent horizontally but spaced vertically in the destination raster, this approach caused many scattered writes jumping across raster pitches.

By reversing the loops (outer: row iteration, inner: character iteration), the destination writes are now strictly contiguous and horizontal across the raster width for each row. This significantly improves L1/L2 cache locality and write-combining during memory transfer. Strict aliasing and memory alignment behaviors correctly rely on modern compiler behavior regarding `memcpy`.