### PR TITLE
fix(lights): fallback to position X when reverse light dummy side suffix is missing

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -21,4 +21,4 @@
 
 extern bool gbProperShadersDetected;
 
-#define STR_FOUND(x, y) x.find(y) != std::string::npos
+#define STR_FOUND(x, y) ((x).find(y) != std::string::npos)

--- a/src/features/lights/components/reverse_light.cpp
+++ b/src/features/lights/components/reverse_light.cpp
@@ -11,10 +11,14 @@ eMaterialType ReverseLightComponent::GetMatType(CRGBA matCol) {
 }
 
 bool ReverseLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::string_view name, VehLightData& data) {
-    if (name.starts_with("rev") && (STR_FOUND(name, "_l") || STR_FOUND(name, "_r"))) {
+    if (name.starts_with("rev")) {
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
+        bool isLeft = STR_FOUND(name, "_l");
+        if (!isLeft && !STR_FOUND(name, "_r")) {
+            isLeft = (c.position.x < 0.0f);
+        }
         c.dummyPos = eDummyPos::Rear;
-        c.lightType = STR_FOUND(name, "_l") ? eMaterialType::ReverseLightLeft : eMaterialType::ReverseLightRight;
+        c.lightType = isLeft ? eMaterialType::ReverseLightLeft : eMaterialType::ReverseLightRight;
         c.corona.lightingType = eLightingMode::Directional;
         data.dummies[c.lightType].push_back(new VehicleDummy(c));
         return true;


### PR DESCRIPTION
When reverse light dummies are named without explicit `_l` or `_r` side suffixes (e.g. `reverselight`), fallback to checking the dummy frame's local X position (`pos.x < 0` for left, `pos.x >= 0` for right) so both reverse lights are correctly identified and illuminated.