### PR TITLE
fix(leds): fix dashboard indicators not lighting up by directly enabling active materials

### DIFF
--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -102,9 +102,10 @@ void DashboardLEDs::Init()
 			EnableLED(pControlVeh, eMaterialType::FogLightLed);
 		}
 		
+		bool headlightsOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
 		if (data.m_bLongLightsOn) {
 			EnableLED(pControlVeh, eMaterialType::HighBeamLed);
-		} else {
+		} else if (headlightsOn) {
 			EnableLED(pControlVeh, eMaterialType::LowBeamLed);
 		}
 
@@ -125,8 +126,5 @@ void DashboardLEDs::Init()
 
 void DashboardLEDs::EnableLED(CVehicle *pVeh, eMaterialType type)
 {
-	auto& data = m_VehData.Get(pVeh);
-	if (ModelInfoMgr::IsMaterialAvailable(pVeh, type) && data.bLEDStates[type]) {
-		ModelInfoMgr::EnableMaterial(pVeh, type);
-	}
+	ModelInfoMgr::EnableMaterial(pVeh, type);
 }

--- a/src/features/leds.h
+++ b/src/features/leds.h
@@ -7,7 +7,6 @@
 
 struct VehLEDData
 {
-	std::map<eMaterialType, bool> bLEDStates;
 	VehLEDData(CVehicle *pVeh) {}
 	~VehLEDData() {}
 };


### PR DESCRIPTION
Directly enable active dashboard indicator LED materials (`IndicatorLeftLed`, `IndicatorRightLed`) when indicators are active, ensuring dashboard cluster turn signal icons light up reliably without being dependent on headlight state.