### PR TITLE
fix(plate): do not illuminate license plate lights on parked vehicles with engine off at night

### DIFF
--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -101,8 +101,7 @@ void DashboardLEDs::Init()
 		if (data.m_bFogLightsOn) {
 			EnableLED(pControlVeh, eMaterialType::FogLightLed);
 		}
-		
-		bool headlightsOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
+		bool headlightsOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
 		if (data.m_bLongLightsOn) {
 			EnableLED(pControlVeh, eMaterialType::HighBeamLed);
 		} else if (headlightsOn) {

--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -114,7 +114,8 @@ RpMaterial *__cdecl LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTextu
         }
     }
 
-    if (pCurrentVeh->m_fHealth > 0.0f && (Util::IsNightTime() || pCurrentVeh->bLightsOn || CarUtil::IsLightsForcedOn(pCurrentVeh)) && !CarUtil::IsLightsForcedOff(pCurrentVeh))
+    bool lightsOn = (pCurrentVeh->bLightsOn || CarUtil::IsLightsForcedOn(pCurrentVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pCurrentVeh))) && !CarUtil::IsLightsForcedOff(pCurrentVeh);
+    if (pCurrentVeh->m_fHealth > 0.0f && lightsOn)
     {
         material->surfaceProps = gLightSurfProps;
         RpMaterialSetTexture(material, m_Plates[plateType + 4]);


### PR DESCRIPTION
Do not illuminate rear license plate background textures on parked vehicles when the engine is off at night, matching vanilla GTA SA headlight and taillight behavior.