### PR TITLE
feat(lights): increase headlight material brightness when high beams are toggled

### DIFF
--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -114,6 +114,23 @@ void Lights::Init()
 		}
 	};
 
+	ModelInfoMgr::RegisterMaterialColProvider([](CVehicle *pVeh, RpMaterial *pMat, eMaterialType type) -> MatStateColor
+	{
+		if (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight)
+		{
+			bool longLights = pVeh && m_VehData.Get(pVeh).m_bLongLightsOn;
+			if (longLights)
+			{
+				return { CRGBA(255, 255, 255, 255), DEFAULT_MAT_COL };
+			}
+			else
+			{
+				return { CRGBA(190, 190, 190, 255), DEFAULT_MAT_COL };
+			}
+		}
+		return { DEFAULT_MAT_COL, DEFAULT_MAT_COL };
+	});
+
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat)
 								   {
 		if (!m_bEnabled) {

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -34,6 +34,18 @@ void LightManager::Init() {
     m_Components.push_back(std::make_unique<AllDayLightComponent>());
     m_Components.push_back(std::make_unique<SideLightComponent>());
     m_Components.push_back(std::make_unique<SpotLightComponent>());
+
+    ModelInfoMgr::RegisterMaterialColProvider([](CVehicle* pVeh, RpMaterial* pMat, eMaterialType type) -> MatStateColor {
+        if (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) {
+            bool longLights = pVeh && m_VehData.Get(pVeh).bLongLightsOn;
+            if (longLights) {
+                return { CRGBA(255, 255, 255, 255), DEFAULT_MAT_COL };
+            } else {
+                return { CRGBA(190, 190, 190, 255), DEFAULT_MAT_COL };
+            }
+        }
+        return { DEFAULT_MAT_COL, DEFAULT_MAT_COL };
+    });
 }
 
 DummyConfig LightManager::CreateBaseConfig(CVehicle* pVeh, RwFrame* pFrame) {


### PR DESCRIPTION
Adjust headlight material ambient and color properties when high beams (long lights) are active to visually differentiate high beam vs low beam headlight material glow.