### PR TITLE
fix(lights): disable headlight high-beam pointlight when headlights are off or damaged

### DIFF
--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -406,7 +406,7 @@ void Lights::Init()
 			}
 
 			static uint32_t longLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", VK_G);
-			if (Util::IsKeyPressed(longLightKey) && (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh)))
+			if (Util::IsKeyPressed(longLightKey) && (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh)) && !CarUtil::IsLightsForcedOff(pVeh))
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
 				if (now - prev > 500.0f)
@@ -468,7 +468,8 @@ void Lights::Init()
 
 			// High beam only. The low beam light is the game's own, doubling up there
 			// would just brighten it instead of extending the reach.
-			if (!m_VehData.Get(pVeh).m_bLongLightsOn || !(pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh)))
+			bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh)) && !CarUtil::IsLightsForcedOff(pVeh);
+			if (!m_VehData.Get(pVeh).m_bLongLightsOn || !isHeadlightsOn)
 			{
 				continue;
 			}
@@ -482,6 +483,12 @@ void Lights::Init()
 			for (eMaterialType type : {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight})
 			{
 				if (!IsDummyAvail(pVeh, type) || !GetLightState(pVeh, type))
+				{
+					continue;
+				}
+
+				eLights lightEnum = (type == eMaterialType::HeadLightLeft) ? eLights::LIGHT_FRONT_LEFT : eLights::LIGHT_FRONT_RIGHT;
+				if (Util::IsLightDamaged(pVeh, lightEnum))
 				{
 					continue;
 				}

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -137,11 +137,14 @@ void LightManager::RenderLight(CVehicle* pVeh, VehLightData& data, eMaterialType
             // on a camera facing check that's true in the normal driving view.
             // High beam only, the low beam light comes from the game itself.
             if ((type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) && data.bLongLightsOn) {
-                // Clamped so a bad ini value can't hand the game a silly or negative range
-                static float rawMul = gConfig.ReadFloat("TWEAKS", "HighBeamPointLightMul", 2.0f);
-                static float highBeamMul = (rawMul < 1.0f) ? 1.0f : ((rawMul > 4.0f) ? 4.0f : rawMul);
+                bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh)) && !CarUtil::IsLightsForcedOff(pVeh);
+                if (isHeadlightsOn) {
+                    // Clamped so a bad ini value can't hand the game a silly or negative range
+                    static float rawMul = gConfig.ReadFloat("TWEAKS", "HighBeamPointLightMul", 2.0f);
+                    static float highBeamMul = (rawMul < 1.0f) ? 1.0f : ((rawMul > 4.0f) ? 4.0f : rawMul);
 
-                RenderUtil::RegisterHeadlightPointLight(&dummy->Get(), highBeamMul);
+                    RenderUtil::RegisterHeadlightPointLight(&dummy->Get(), highBeamMul);
+                }
             }
 
             if (c.shadow.render && !texture.empty()) {


### PR DESCRIPTION
### Summary
Ensures headlight high beam pointlights and long light coronas are automatically suppressed when vehicle headlights are off, engine is off, or front light clusters are damaged.

### Changes
- Check light damage state and active headlight state before emitting high beam pointlights.
- Fix high beam pointlight remaining active when headlights are turned off.