### PR TITLE
feat(plate): decouple plate on-ambient from INI and set constant 50.0 brightness

### DIFF
--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -117,7 +117,8 @@ RpMaterial *__cdecl LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTextu
     bool lightsOn = (pCurrentVeh->bLightsOn || CarUtil::IsLightsForcedOn(pCurrentVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pCurrentVeh))) && !CarUtil::IsLightsForcedOff(pCurrentVeh);
     if (pCurrentVeh->m_fHealth > 0.0f && lightsOn)
     {
-        material->surfaceProps = gLightSurfProps;
+        // material->surfaceProps = gLightSurfProps;
+        material->surfaceProps = {50.0f, 0.0f, 0.0f};
         RpMaterialSetTexture(material, m_Plates[plateType + 4]);
     }
     else


### PR DESCRIPTION
### Summary
Decouples license plate night-on ambient brightness from `MaterialAmbientOn` in INI and sets it to a constant 50.0 brightness, ensuring license plates are always crisp and legible at night regardless of custom headlight glow settings.

### Changes
- Set license plate active ambient property to constant 50.0f.