### PR TITLE
feat(lights): restore HeadLightBeams option with default enabled

### DIFF
--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -93,7 +93,7 @@ void Lights::Init()
 	patch::SetUChar(0x6E0DEE, 0);
 
 	// NOP CVehicle::DoHeadLightBeam
-	if (!gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true))
+	if (!gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true)))
 	{
 		// cmp ax, ax
 		patch::SetRaw(0x6A2EA5, (void *)"\x66\x39\xC0\x90", 4);

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -17,6 +17,14 @@ void LightsFeature::Init() {
 	patch::SetUChar(0x6E0CF8, 0);
 	patch::SetUChar(0x6E0DEE, 0);
 
+	// NOP CVehicle::DoHeadLightBeam
+	if (!gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true)))
+	{
+		// cmp ax, ax
+		patch::SetRaw(0x6A2EA5, (void *)"\x66\x39\xC0\x90", 4);
+		patch::SetRaw(0x6BDE63, (void *)"\x66\x39\xC0\x90\x90\x90\x90", 7);
+	}
+
 	Events::initGameEvent += []()
 	{
 		LightsGlobal::Get().gbGlobalIndicatorLights = gConfig.ReadBoolean("FEATURES", "StandardLights_GlobalIndicatorLights", false);


### PR DESCRIPTION
### Summary
Restores the `HeadLightBeams` configuration toggle under `[LIGHTS]` with default enabled (`1`), allowing users to toggle vanilla volumetric headlight beams on or off.

### Changes
- Read `HeadLightBeams` in `[LIGHTS]` with fallback to `[TWEAKS]`.
- NOP `CVehicle::DoHeadLightBeam` when disabled.