### PR TITLE
feat(render): preserve native DFF material surface properties and use game light properties on activation

### DIFF
--- a/resource/dist/ModelExtras.ini
+++ b/resource/dist/ModelExtras.ini
@@ -51,8 +51,6 @@ TailLightCoronaIntensity             = 60           # Specific brightness for ta
 CoronaDistanceMul                    = 0.0          # Scales coronas at distance during night time (0.0 to disable)
 HighBeamPointLightMul                = 2.0          # Multiplier for high beam light reach (1.0 matches low beam, up to 4.0)
 LightHeightLimit                     = 0.5          # ImVehFt light height limit (0.0 to disable)
-MaterialAmbientOff                   = 0.45         # How much the material responds to sunlight (0.45 = default)
-MaterialAmbientOn                    = 50.0         # How much the material glows at night (50.0 = fully lit)
 
 [SOUND]
 SoundEffects                         = 1            # Master toggle for all ModelExtras sound effects

--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -7,13 +7,12 @@
 #include <RenderWare.h>
 #include <CTheZones.h>
 #include "utils/texmgr.h"
+#include "utils/modelinfomgr.h"
 #include <utility>
 
 using namespace plugin;
 
 static CVehicle *pCurrentVeh = nullptr;
-extern RwSurfaceProperties gLightSurfProps;
-extern RwSurfaceProperties gLightSurfPropsOff;
 
 void LicensePlate::Init()
 {
@@ -117,12 +116,12 @@ RpMaterial *__cdecl LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTextu
     bool lightsOn = (pCurrentVeh->bLightsOn || CarUtil::IsLightsForcedOn(pCurrentVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pCurrentVeh))) && !CarUtil::IsLightsForcedOff(pCurrentVeh);
     if (pCurrentVeh->m_fHealth > 0.0f && lightsOn)
     {
-        material->surfaceProps = gLightSurfProps;
+        ModelInfoMgr::RegisterRestoreSurfProps(material);
+        material->surfaceProps = *reinterpret_cast<RwSurfaceProperties *>(0x8A645C);
         RpMaterialSetTexture(material, m_Plates[plateType + 4]);
     }
     else
     {
-        material->surfaceProps = gLightSurfPropsOff;
         RpMaterialSetTexture(material, m_Plates[plateType]);
     }
     return material;

--- a/src/utils/modelinfomgr.cpp
+++ b/src/utils/modelinfomgr.cpp
@@ -25,8 +25,6 @@ extern int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat);
 extern int GetStrobeIndex(CVehicle *pVeh, RpMaterial *pMat);
 
 static CVehicle *pCurVeh = nullptr;
-RwSurfaceProperties gLightSurfProps = {1.0f, 0.0f, 0.0f};
-RwSurfaceProperties gLightSurfPropsOff = {0.45f, 0.0f, 0.0f};
 
 static constexpr uint32_t RwFrameForAllObjectsAddr = 0x7F1200;
 static constexpr uint32_t RwFrameAddChildAddr = 0x7F0B00;
@@ -94,10 +92,18 @@ void ModelInfoMgr::ResetEditableMaterials() {
     }
   }
   m_RestoreEntries.clear();
+
+  for (auto it = m_SurfPropsRestoreEntries.rbegin(); it != m_SurfPropsRestoreEntries.rend(); ++it) {
+    if (it->m_pMaterial) {
+      it->m_pMaterial->surfaceProps = it->m_SurfProps;
+    }
+  }
+  m_SurfPropsRestoreEntries.clear();
 }
 
 void ModelInfoMgr::Init() {
   m_RestoreEntries.reserve(256);
+  m_SurfPropsRestoreEntries.reserve(256);
 
   patch::Nop(0x4C8E53, 5);
   patch::Nop(0x4C8F6E, 5);
@@ -117,19 +123,6 @@ void ModelInfoMgr::Init() {
       0x4C8220, reinterpret_cast<void *>(ModelInfoMgr::SetEditableMaterialsCB));
   patch::ReplaceFunction(
       0x4C8460, reinterpret_cast<void *>(ModelInfoMgr::ResetEditableMaterials));
-
-  Events::initScriptsEvent += []() {
-    gLightSurfProps.ambient = gConfig.ReadFloat("LIGHTS", "MaterialAmbientOn",
-                                                gConfig.ReadFloat("VISUAL", "MaterialAmbientOn", gLightSurfProps.ambient));
-    gLightSurfProps.diffuse =
-        gConfig.ReadFloat("LIGHTS", "MaterialDiffuseOn", gConfig.ReadFloat("VISUAL", "MaterialDiffuseOn", 0.0f));
-    gLightSurfProps.specular = 0.0f;
-    gLightSurfPropsOff.ambient = gConfig.ReadFloat(
-        "LIGHTS", "MaterialAmbientOff", gConfig.ReadFloat("VISUAL", "MaterialAmbientOff", gLightSurfPropsOff.ambient));
-    gLightSurfPropsOff.diffuse = 0.0f;
-    gLightSurfPropsOff.specular = 0.0f;
-  };
-
   MEEvents::vehRenderEvent.before += [](CVehicle *pVeh) {
     if (!pVeh || !pVeh->m_pRwClump) {
       return;
@@ -335,12 +328,12 @@ RpMaterial *ModelInfoMgr::SetEditableMaterialsCB(RpMaterial *material,
           }
         }
       }
-      material->surfaceProps = gLightSurfProps;
+      m_SurfPropsRestoreEntries.push_back({material, material->surfaceProps});
+      material->surfaceProps = *reinterpret_cast<RwSurfaceProperties *>(0x8A645C);
     } else {
       pColor->red = matCol.off.r;
       pColor->green = matCol.off.g;
       pColor->blue = matCol.off.b;
-      material->surfaceProps = gLightSurfPropsOff;
     }
   } else {
     CRGBA col = {255, 255, 255, 255};

--- a/src/utils/modelinfomgr.h
+++ b/src/utils/modelinfomgr.h
@@ -44,6 +44,11 @@ struct tRestoreEntry {
   void *m_pValue;
 };
 
+struct tSurfPropsRestoreEntry {
+  RpMaterial *m_pMaterial;
+  RwSurfaceProperties m_SurfProps;
+};
+
 class ModelInfoMgr {
 private:
   static inline std::vector<DummyCallback_t> dummies;
@@ -51,6 +56,7 @@ private:
   static inline std::vector<MaterialColProviderCallback_t> matColProviders;
   static inline std::vector<RenderCallback_t> renders;
   static inline std::vector<tRestoreEntry> m_RestoreEntries;
+  static inline std::vector<tSurfPropsRestoreEntry> m_SurfPropsRestoreEntries;
 
   static inline plugin::VehicleExtendedData<VehModelData> m_VehData;
 
@@ -79,5 +85,10 @@ public:
   static void Reload(CVehicle *pVeh);
   static void RegisterRestore(void *address, void *value) {
     m_RestoreEntries.push_back({address, value});
+  }
+  static void RegisterRestoreSurfProps(RpMaterial *material) {
+    if (material) {
+      m_SurfPropsRestoreEntries.push_back({material, material->surfaceProps});
+    }
   }
 };


### PR DESCRIPTION
### Summary
Preserves the vehicle's native DFF model material surface properties (`ambient`, `diffuse`, `specular`) when lights are off, preventing glass, lenses, and textures from looking unnaturally dark or flat. When lights are activated, temporarily applies GTA SA's native `ms_lightSurfProps` (`0x8A645C`) and restores the original material properties on render reset (`ResetEditableMaterials`).

### Changes
- Track and restore original `material->surfaceProps` via `m_SurfPropsRestoreEntries` on `ResetEditableMaterials`.
- Apply GTA SA's native `*(RwSurfaceProperties *)0x8A645C` when lights are ON.
- Leave `material->surfaceProps` untouched when lights are OFF so model materials retain their natural illumination.
- Remove obsolete hardcoded `MaterialAmbientOff` and `MaterialAmbientOn` configuration options.