### PR TITLE
feat(audio): implement dynamic 3D positional audio and CLEO 4.4.4+ / CLEO 5 BASS engine

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -29,6 +29,53 @@ void InitLog()
     LOG(INFO) << header;
 }
 
+#pragma comment(lib, "version.lib")
+
+static bool GetCleoVersion(HMODULE hCleo, int &major, int &minor, int &patch)
+{
+    major = minor = patch = 0;
+
+    // Method 1: Exported function (CLEO 5+)
+    typedef DWORD(WINAPI *tCLEO_GetVersion)();
+    auto pfnGetVersion = (tCLEO_GetVersion)GetProcAddress(hCleo, "CLEO_GetVersion");
+    if (pfnGetVersion)
+    {
+        DWORD ver = pfnGetVersion();
+        major = (ver >> 24) & 0xFF;
+        minor = (ver >> 16) & 0xFF;
+        patch = (ver >> 8) & 0xFF;
+        if (major > 0)
+        {
+            return true;
+        }
+    }
+
+    // Method 2: PE File Version Info from CLEO.asi (works for all CLEO 4 and 5 versions)
+    char szModulePath[MAX_PATH] = {0};
+    if (GetModuleFileNameA(hCleo, szModulePath, MAX_PATH) > 0)
+    {
+        DWORD dwHandle = 0;
+        DWORD dwSize = GetFileVersionInfoSizeA(szModulePath, &dwHandle);
+        if (dwSize > 0)
+        {
+            std::vector<BYTE> data(dwSize);
+            if (GetFileVersionInfoA(szModulePath, dwHandle, dwSize, data.data()))
+            {
+                VS_FIXEDFILEINFO *pFileInfo = nullptr;
+                UINT uLen = 0;
+                if (VerQueryValueA(data.data(), "\\", (LPVOID *)&pFileInfo, &uLen) && pFileInfo && uLen >= sizeof(VS_FIXEDFILEINFO))
+                {
+                    major = HIWORD(pFileInfo->dwFileVersionMS);
+                    minor = LOWORD(pFileInfo->dwFileVersionMS);
+                    patch = HIWORD(pFileInfo->dwFileVersionLS);
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 BOOL WINAPI DllMain(HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved)
 {
     if (nReason == DLL_PROCESS_ATTACH)
@@ -43,10 +90,40 @@ BOOL WINAPI DllMain(HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved)
                 LOG(INFO) << "Enable 'VerboseLogging' in ModelExtras.ini to display model-related errors.";
             }
 
-            if (!GetModuleHandle("CLEO.asi"))
+            HMODULE hCleo = GetModuleHandleA("CLEO.asi");
+            if (!hCleo)
             {
-                MessageBox(RsGlobal.ps->window, "CLEO Library 4.4 or above is required!", "ModelExtras", MB_OK);
-                LOG(ERROR) << "CLEO Library 4.4 or above is required!";
+                MessageBoxA(RsGlobal.ps ? RsGlobal.ps->window : NULL,
+                            "CLEO Library 4.4.4 or above is required!\nCLEO.asi was not found.",
+                            "ModelExtras", MB_OK | MB_ICONERROR);
+                LOG(ERROR) << "CLEO Library 4.4.4 or above is required! CLEO.asi was not found.";
+            }
+            else
+            {
+                int major = 0, minor = 0, patch = 0;
+                if (GetCleoVersion(hCleo, major, minor, patch))
+                {
+                    // Minimum version required: CLEO 4.4.4 (or CLEO 5+)
+                    bool isOutdated = (major < 4) ||
+                                      (major == 4 && (minor < 4 || (minor == 4 && patch < 4)));
+
+                    if (isOutdated)
+                    {
+                        char msg[256];
+                        sprintf_s(msg,
+                                  "CLEO Library 4.4.4 or above is required!\n"
+                                  "Detected CLEO version: %d.%d.%d\n"
+                                  "Please update CLEO to 4.4.4 or above to avoid audio issues.",
+                                  major, minor, patch);
+
+                        MessageBoxA(RsGlobal.ps ? RsGlobal.ps->window : NULL, msg, "ModelExtras", MB_OK | MB_ICONWARNING);
+                        LOG(WARNING) << msg;
+                    }
+                    else
+                    {
+                        LOG(INFO) << "CLEO version " << major << "." << minor << "." << patch << " detected.";
+                    }
+                }
             }
         };
         ModelExtras::Init();

--- a/src/features/backfire.cpp
+++ b/src/features/backfire.cpp
@@ -23,10 +23,9 @@ void BackFireEffect::BackFireFX(CVehicle *pVeh, float x, float y, float z, float
 
     Command<Commands::PLAY_AND_KILL_FX_SYSTEM>(handle);
 
-    CVector vehPos = pVeh->GetPosition();
-    CVector camPos = TheCamera.GetPosition();
+    CVector exhaustWorldPos = pVeh->TransformFromObjectSpace(CVector(x, y, z));
     static std::string audioPath = MOD_DATA_PATH("audio/backfire.wav");
-    AudioMgr::PlayFileSound(audioPath, pVeh, 1.5f, true);
+    AudioMgr::Play3DSound(audioPath, exhaustWorldPos, pVeh, 1.5f, 80.0f);
 }
 
 void BackFireEffect::BackFireSingle(CVehicle *pVeh)

--- a/src/features/soundeffects.cpp
+++ b/src/features/soundeffects.cpp
@@ -12,29 +12,46 @@ std::vector<int> ValidForReverseSound;
 #define ANIMGROUP_BUS 15
 #define ANIMGROUP_COACH 16
 
+static bool bReverseSounds = false;
+static bool bEngineSounds = false;
+static bool bIndicatorSounds = false;
+static bool bAirbreakSounds = false;
+static bool bOnlyPlayerVehicle = true;
+
+void SoundEffects::ReloadConfig()
+{
+    std::string line = gConfig.ReadString("TABLE", "SoundEffects_BigVehicleModels", "");
+    ValidForReverseSound.clear();
+    Util::GetModelsFromIni(line, ValidForReverseSound);
+
+    bReverseSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalReverseSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalReverseSound", false));
+    bEngineSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalEngineSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalEngineSound", false));
+    bIndicatorSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalIndicatorSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalIndicatorSound", false));
+    bAirbreakSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalAirbreakSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalAirbreakSound", false));
+    bOnlyPlayerVehicle = !gConfig.ReadBoolean("SOUND", "SoundEffects_NonPlayerVehicles", gConfig.ReadBoolean("FEATURES", "SoundEffects_NonPlayerVehicles", false));
+}
+
+void SoundEffects::Reload(CVehicle *pVeh)
+{
+    ReloadConfig();
+}
+
 void SoundEffects::Init()
 {
-    static bool bReverseSounds = false;
-    static bool bEngineSounds = false;
-    static bool bIndicatorSounds = false;
-    static bool bAirbreakSounds = false;
-    static bool bOnlyPlayerVehicle = true;
-
     Events::initGameEvent += []()
     {
-        std::string line = gConfig.ReadString("TABLE", "SoundEffects_BigVehicleModels", "");
-        Util::GetModelsFromIni(line, ValidForReverseSound);
-
-        bReverseSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalReverseSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalReverseSound", false));
-        bEngineSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalEngineSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalEngineSound", false));
-        bIndicatorSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalIndicatorSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalIndicatorSound", false));
-        bAirbreakSounds = gConfig.ReadBoolean("SOUND", "SoundEffects_GlobalAirbreakSound", gConfig.ReadBoolean("FEATURES", "SoundEffects_GlobalAirbreakSound", false));
-        bOnlyPlayerVehicle = !gConfig.ReadBoolean("SOUND", "SoundEffects_NonPlayerVehicles", gConfig.ReadBoolean("FEATURES", "SoundEffects_NonPlayerVehicles", false));
+        ReloadConfig();
     };
 
     Events::processScriptsEvent += []() {
+        CPed *pPlayer = FindPlayerPed();
+        if (!pPlayer) {
+            return;
+        }
+        CVector playerPos = pPlayer->GetPosition();
+
 		for (CVehicle *pVeh : CPools::ms_pVehiclePool) {
-			if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) > 50.0f ) {
+			if (CVector::Distance(pVeh->GetPosition(), playerPos) > 75.0f ) {
 				continue;
 			}
 
@@ -56,9 +73,10 @@ void SoundEffects::Init()
                 continue;
             }
 
-            int animGroup = pVeh->m_pHandlingData->m_nAnimGroup;
+            int animGroup = pVeh->m_pHandlingData ? pVeh->m_pHandlingData->m_nAnimGroup : 0;
             bool isAllowed = pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE &&
-                            (animGroup == ANIMGROUP_TRUCK || animGroup == ANIMGROUP_BUS || animGroup == ANIMGROUP_COACH);
+                            (animGroup == ANIMGROUP_TRUCK || animGroup == ANIMGROUP_BUS || animGroup == ANIMGROUP_COACH ||
+                             pVeh->bIsBig || pVeh->bIsBus || pVeh->bIsVan || (pVeh->m_pHandlingData && pVeh->m_pHandlingData->m_fMass >= 3500.0f));
             bool isBigVeh = isAllowed || std::find(ValidForReverseSound.begin(), ValidForReverseSound.end(), pVeh->m_nModelIndex) != ValidForReverseSound.end();
 
             if (bEngineSounds)
@@ -78,11 +96,11 @@ void SoundEffects::Init()
                             static std::string bikePath = MOD_DATA_PATH("audio/bike_engine_start.wav");
                             if (CModelInfo::IsBikeModel(model) || CModelInfo::IsQuadBikeModel(model))
                             {
-                                AudioMgr::PlayFileSound(bikePath, pVeh, 1.0f, true);
+                                AudioMgr::Play3DSound(bikePath, pVeh->GetPosition(), pVeh, 1.0f, 65.0f);
                             }
                             else
                             {
-                                AudioMgr::PlayFileSound(carPath, pVeh, 1.0f, true);
+                                AudioMgr::Play3DSound(carPath, pVeh->GetPosition(), pVeh, 1.0f, 65.0f);
                             }
                             data.m_nLastEngineSoundTime = curTime;
                         }
@@ -102,18 +120,15 @@ void SoundEffects::Init()
 
                     if (state)
                     {
-                        AudioMgr::PlayFileSound(onpath, pVeh, 0.6f, true);
+                        AudioMgr::PlayFileSound(onpath, 0.6f);
                     }
                     else
                     {
-                        AudioMgr::PlayFileSound(offpath, pVeh, 0.6f, true);
+                        AudioMgr::PlayFileSound(offpath, 0.6f);
                     }
                     data.m_bIndicatorState = state;
                 }
             }
-
-            CVector vehPos = pVeh->GetPosition();
-            CVector camPos = TheCamera.GetPosition();
 
             if (bAirbreakSounds && isBigVeh)
             {
@@ -132,7 +147,7 @@ void SoundEffects::Init()
                 if (pedal <= 0.05f && data.m_fMaxPedal > 0.0f)
                 {
                     static std::string path = MOD_DATA_PATH("audio/airbreak.wav");
-                    AudioMgr::PlayFileSound(path, pVeh, data.m_fBrakePressure, true);
+                    AudioMgr::Play3DSound(path, pVeh->GetPosition(), pVeh, data.m_fBrakePressure, 60.0f);
                     data.m_fMaxPedal = 0.0f;
                     data.m_fBrakePressure = 0.0f;
                 }
@@ -147,7 +162,7 @@ void SoundEffects::Init()
                     unsigned int curTime = CTimer::m_snTimeInMilliseconds;
                     if (curTime - data.m_nLastReverseSoundTime >= 1000)
                     {
-                        AudioMgr::PlayFileSound(path, pVeh, 0.5f, true);
+                        AudioMgr::Play3DSound(path, pVeh->GetPosition(), pVeh, 0.7f, 50.0f);
                         data.m_nLastReverseSoundTime = curTime;
                     }
                 }

--- a/src/features/soundeffects.h
+++ b/src/features/soundeffects.h
@@ -19,12 +19,11 @@ struct SoundEffectsData
 
 class SoundEffects : public CVehFeature<SoundEffectsData>
 {
-private:
-    
-
 protected:
     void Init() override;
+    void Reload(CVehicle *pVeh) override;
+    static void ReloadConfig();
 
 public:
-    SoundEffects() : CVehFeature<SoundEffectsData>("SoundEffects", "FEATURES", eFeatureMatrix::SoundEffects) {}
+    SoundEffects() : CVehFeature<SoundEffectsData>("SoundEffects", "SOUND", eFeatureMatrix::SoundEffects) {}
 };

--- a/src/utils/audiomgr.cpp
+++ b/src/utils/audiomgr.cpp
@@ -1,24 +1,69 @@
 #include "pch.h"
 #include "utils/audiomgr.h"
 #include "defines.h"
-#include <cstdint>
-#include <extensions/ScriptCommands.h>
 #include <CAudioEngine.h>
+#include <CCamera.h>
+#include <algorithm>
 
 using namespace plugin;
 
-enum : uint16_t {
-    LOAD_AUDIO_STREAM = 0x0AAC,
-    LOAD_3D_AUDIO_STREAM = 0x0AC1,
-    SET_PLAY_3D_AUDIO_STREAM_AT_COORDS = 0x0AC2,
-    SET_PLAY_3D_AUDIO_STREAM_AT_OBJECT = 0x0AC3,
-    SET_PLAY_3D_AUDIO_STREAM_AT_CHAR = 0x0AC4,
-    SET_PLAY_3D_AUDIO_STREAM_AT_CAR = 0x0AC5,
-    SET_AUDIO_STREAM_STATE = 0x0AAD,
-    GET_AUDIO_STREAM_STATE = 0x0AB9,
-    REMOVE_AUDIO_STREAM = 0x0AAE,
-    SET_AUDIO_STREAM_VOLUME = 0x0ABC
-};
+// Minimal dynamic BASS API (CLEO 4.4.4+ / CLEO 5 engine)
+namespace BassAPI
+{
+    using HSTREAM = uint32_t;
+    using QWORD = uint64_t;
+
+    using tBASS_Init = BOOL(WINAPI *)(int, DWORD, DWORD, HWND, const void *);
+    using tBASS_StreamCreateFile = HSTREAM(WINAPI *)(BOOL, const void *, QWORD, QWORD, DWORD);
+    using tBASS_ChannelPlay = BOOL(WINAPI *)(DWORD, BOOL);
+    using tBASS_ChannelPause = BOOL(WINAPI *)(DWORD);
+    using tBASS_ChannelSetAttribute = BOOL(WINAPI *)(DWORD, DWORD, float);
+    using tBASS_ChannelIsActive = DWORD(WINAPI *)(DWORD);
+    using tBASS_StreamFree = BOOL(WINAPI *)(HSTREAM);
+
+    static tBASS_Init fnInit = nullptr;
+    static tBASS_StreamCreateFile fnStreamCreate = nullptr;
+    static tBASS_ChannelPlay fnChannelPlay = nullptr;
+    static tBASS_ChannelPause fnChannelPause = nullptr;
+    static tBASS_ChannelSetAttribute fnChannelSetAttr = nullptr;
+    static tBASS_ChannelIsActive fnChannelIsActive = nullptr;
+    static tBASS_StreamFree fnStreamFree = nullptr;
+
+    static bool bReady = false;
+
+    static void Init()
+    {
+        if (bReady)
+        {
+            return;
+        }
+
+        HMODULE hBass = GetModuleHandleA("bass.dll");
+        if (!hBass)
+        {
+            hBass = LoadLibraryA("bass.dll");
+        }
+
+        if (hBass)
+        {
+            fnInit = (tBASS_Init)GetProcAddress(hBass, "BASS_Init");
+            fnStreamCreate = (tBASS_StreamCreateFile)GetProcAddress(hBass, "BASS_StreamCreateFile");
+            fnChannelPlay = (tBASS_ChannelPlay)GetProcAddress(hBass, "BASS_ChannelPlay");
+            fnChannelPause = (tBASS_ChannelPause)GetProcAddress(hBass, "BASS_ChannelPause");
+            fnChannelSetAttr = (tBASS_ChannelSetAttribute)GetProcAddress(hBass, "BASS_ChannelSetAttribute");
+            fnChannelIsActive = (tBASS_ChannelIsActive)GetProcAddress(hBass, "BASS_ChannelIsActive");
+            fnStreamFree = (tBASS_StreamFree)GetProcAddress(hBass, "BASS_StreamFree");
+
+            if (fnInit && fnStreamCreate && fnChannelPlay && fnChannelPause && fnChannelSetAttr && fnChannelIsActive && fnStreamFree)
+            {
+                HWND hWnd = (RsGlobal.ps && RsGlobal.ps->window) ? RsGlobal.ps->window : NULL;
+                fnInit(-1, 44100, 0, hWnd, nullptr);
+                bReady = true;
+                LOG_VERBOSE("AudioMgr: BASS audio engine initialized successfully.");
+            }
+        }
+    }
+}
 
 static bool gbSoundEffectsEnabled = false;
 static float gfSoundMult = 1.0f;
@@ -33,16 +78,17 @@ void AudioMgr::Init()
 {
     Events::initGameEvent += []
     {
+        BassAPI::Init();
         ReloadConfig();
     };
 
     Events::reInitGameEvent += []
     {
-        for (auto it : needToFree)
+        for (auto stream : needToFree)
         {
-            if (it != NULL)
+            if (stream && BassAPI::fnStreamFree)
             {
-                Command<REMOVE_AUDIO_STREAM>(it);
+                BassAPI::fnStreamFree(stream);
             }
         }
         needToFree.clear();
@@ -50,6 +96,37 @@ void AudioMgr::Init()
 
     Events::processScriptsEvent += []
     {
+        static bool bWasPaused = false;
+        bool bIsPaused = CTimer::m_UserPause || CTimer::m_CodePause;
+
+        if (bIsPaused != bWasPaused)
+        {
+            bWasPaused = bIsPaused;
+            if (BassAPI::bReady && BassAPI::fnChannelPause && BassAPI::fnChannelPlay && BassAPI::fnChannelIsActive)
+            {
+                for (auto stream : needToFree)
+                {
+                    if (stream)
+                    {
+                        if (bIsPaused)
+                        {
+                            if (BassAPI::fnChannelIsActive(stream) == 1 /* BASS_ACTIVE_PLAYING */)
+                            {
+                                BassAPI::fnChannelPause(stream);
+                            }
+                        }
+                        else
+                        {
+                            if (BassAPI::fnChannelIsActive(stream) == 3 /* BASS_ACTIVE_PAUSED */)
+                            {
+                                BassAPI::fnChannelPlay(stream, FALSE);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         static size_t prev = 0;
         size_t cur = CTimer::m_snTimeInMilliseconds;
 
@@ -57,18 +134,12 @@ void AudioMgr::Init()
         {
             for (auto it = needToFree.begin(); it != needToFree.end();)
             {
-                if (!*it)
+                if (!*it || !BassAPI::fnChannelIsActive || BassAPI::fnChannelIsActive(*it) == 0 /* BASS_ACTIVE_STOPPED */)
                 {
-                    it = needToFree.erase(it);
-                    continue;
-                }
-
-                int state = eAudioStreamState::Stopped;
-                Command<GET_AUDIO_STREAM_STATE>(*it, &state);
-                if (state == eAudioStreamState::Stopped || state == eAudioStreamState::Paused)
-                {
-                    Command<REMOVE_AUDIO_STREAM>(*it);
-                    *it = NULL;
+                    if (*it && BassAPI::fnStreamFree)
+                    {
+                        BassAPI::fnStreamFree(*it);
+                    }
                     it = needToFree.erase(it);
                 }
                 else
@@ -76,9 +147,8 @@ void AudioMgr::Init()
                     ++it;
                 }
             }
-
             prev = cur;
-        };
+        }
     };
 }
 
@@ -93,46 +163,8 @@ void AudioMgr::PlayClickSound()
 
 void AudioMgr::PlaySwitchSound(CEntity *pEntity)
 {
-    if (!ShouldPlaySound())
-    {
-        return;
-    }
     static std::string path = MOD_DATA_PATH("audio/switch_toggle.wav");
-    PlayFileSound(path, pEntity, 1.0f, true);
-}
-
-static std::unordered_map<std::string, bool> is3DSupported;
-
-StreamHandle AudioMgr::Load(const std::string &path)
-{
-    if (path.empty())
-    {
-        return NULL;
-    }
-
-    StreamHandle handle = NULL;
-    if (!is3DSupported.contains(path) || is3DSupported[path])
-    {
-        Command<LOAD_3D_AUDIO_STREAM>(path.c_str(), &handle);
-    }
-
-    if (handle != NULL)
-    {
-        is3DSupported[path] = true;
-    }
-    else
-    {
-        Command<LOAD_AUDIO_STREAM>(path.c_str(), &handle);
-        if (handle == NULL)
-        {
-            LOG_VERBOSE("Failed to load sound '{}'", path);
-        }
-        else
-        {
-            is3DSupported[path] = false;
-        }
-    }
-    return handle;
+    PlayFileSound(path, 1.0f);
 }
 
 bool AudioMgr::ShouldPlaySound()
@@ -140,70 +172,98 @@ bool AudioMgr::ShouldPlaySound()
     return gbSoundEffectsEnabled;
 }
 
-void AudioMgr::PlayFileSound(const std::string &path, CEntity *pEntity, float volume, bool cached)
+void AudioMgr::Play3DSound(const std::string &path, const CVector &worldPos, CEntity *pEntity, float baseVolume, float maxDistance)
 {
-    if (!ShouldPlaySound())
+    if (!ShouldPlaySound() || path.empty())
     {
         return;
     }
 
-    StreamHandle handle = Load(path);
-    if (handle == NULL)
+    CVector listenerPos = TheCamera.GetPosition();
+    float dist = CVector::Distance(worldPos, listenerPos);
+    if (dist > maxDistance)
+    {
+        return; // Beyond maximum audible range: cull
+    }
+
+    // Natural smooth distance attenuation
+    // Full volume within near radius (5m), then linear acoustic decay up to maxDistance
+    const float nearDist = 5.0f;
+    float distFactor = 1.0f;
+    if (dist > nearDist)
+    {
+        float ratio = std::clamp((dist - nearDist) / (maxDistance - nearDist), 0.0f, 1.0f);
+        distFactor = 1.0f - ratio;
+    }
+
+    // 3D camera-relative stereo panning (-1.0 = left, 0.0 = center, +1.0 = right)
+    float pan = 0.0f;
+    if (dist > 0.1f)
+    {
+        CVector toSound = worldPos - listenerPos;
+        CVector camRight = TheCamera.m_mCameraMatrix.right;
+        float rightDot = (toSound.x * camRight.x + toSound.y * camRight.y + toSound.z * camRight.z) / dist;
+        pan = std::clamp(rightDot, -1.0f, 1.0f);
+    }
+
+    // Calibrated volume scaling with in-game SFX master volume (0xBA6797)
+    float masterSfxVol = *(BYTE *)0xBA6797 / 64.0f;
+    float finalVolume = baseVolume * distFactor * gfSoundMult * masterSfxVol;
+    if (finalVolume < 0.005f)
     {
         return;
     }
 
-    needToFree.push_back(handle);
-
-    int state = eAudioStreamState::Stopped;
-    Command<GET_AUDIO_STREAM_STATE>(handle, &state);
-
-    if (state != eAudioStreamState::Playing)
+    if (BassAPI::bReady && BassAPI::fnStreamCreate)
     {
-        SetVolume(handle, volume);
-        if (pEntity == nullptr)
+        BassAPI::HSTREAM stream = BassAPI::fnStreamCreate(FALSE, path.c_str(), 0, 0, 0);
+        if (!stream)
         {
-            pEntity = FindPlayerPed();
+            std::string altPath = path;
+            std::replace(altPath.begin(), altPath.end(), '/', '\\');
+            stream = BassAPI::fnStreamCreate(FALSE, altPath.c_str(), 0, 0, 0);
         }
 
-        // We're verifying the type so static_cast should be fine 
-        if (pEntity->m_nType == ENTITY_TYPE_VEHICLE)
+        if (stream)
         {
-            int hEntity = CPools::GetVehicleRef(static_cast<CVehicle *>(pEntity));
-            if (hEntity != NULL)
-            {
-                Command<SET_PLAY_3D_AUDIO_STREAM_AT_CAR>(handle, hEntity);
-            }
+            BassAPI::fnChannelSetAttr(stream, 2 /* BASS_ATTRIB_VOL */, std::clamp(finalVolume, 0.0f, 1.0f));
+            BassAPI::fnChannelSetAttr(stream, 3 /* BASS_ATTRIB_PAN */, pan);
+            BassAPI::fnChannelPlay(stream, TRUE);
+            needToFree.push_back(stream);
         }
-        else if (pEntity->m_nType == ENTITY_TYPE_PED)
-        {
-            int hEntity = CPools::GetPedRef(static_cast<CPed *>(pEntity));
-            if (hEntity != NULL)
-            {
-                Command<SET_PLAY_3D_AUDIO_STREAM_AT_CHAR>(handle, hEntity);
-            }
-        }
-        else if (pEntity->m_nType == ENTITY_TYPE_OBJECT)
-        {
-            int hEntity = CPools::GetObjectRef(static_cast<CObject *>(pEntity));
-            if (hEntity != NULL)
-            {
-                Command<SET_PLAY_3D_AUDIO_STREAM_AT_OBJECT>(handle, hEntity);
-            }
-        }
-        else
-        {
-            const CVector &pos = pEntity->GetPosition();
-            Command<SET_PLAY_3D_AUDIO_STREAM_AT_COORDS>(handle, pos.x, pos.y, pos.z);
-        }
-        Command<SET_AUDIO_STREAM_STATE>(handle, static_cast<int>(eAudioStreamState::Playing));
     }
 }
 
-void AudioMgr::SetVolume(StreamHandle handle, float volume)
+void AudioMgr::PlayFileSound(const std::string &path, float volume)
 {
-    if (handle != NULL)
+    if (!ShouldPlaySound() || path.empty())
     {
-        Command<SET_AUDIO_STREAM_VOLUME>(handle, *(BYTE *)0xBA6797 / 64.0f * volume * gfSoundMult);
+        return;
+    }
+
+    float masterSfxVol = *(BYTE *)0xBA6797 / 64.0f;
+    float finalVolume = volume * gfSoundMult * masterSfxVol;
+    if (finalVolume < 0.005f)
+    {
+        return;
+    }
+
+    if (BassAPI::bReady && BassAPI::fnStreamCreate)
+    {
+        BassAPI::HSTREAM stream = BassAPI::fnStreamCreate(FALSE, path.c_str(), 0, 0, 0);
+        if (!stream)
+        {
+            std::string altPath = path;
+            std::replace(altPath.begin(), altPath.end(), '/', '\\');
+            stream = BassAPI::fnStreamCreate(FALSE, altPath.c_str(), 0, 0, 0);
+        }
+
+        if (stream)
+        {
+            BassAPI::fnChannelSetAttr(stream, 2 /* BASS_ATTRIB_VOL */, std::clamp(finalVolume, 0.0f, 1.0f));
+            BassAPI::fnChannelSetAttr(stream, 3 /* BASS_ATTRIB_PAN */, 0.0f);
+            BassAPI::fnChannelPlay(stream, TRUE);
+            needToFree.push_back(stream);
+        }
     }
 }

--- a/src/utils/audiomgr.h
+++ b/src/utils/audiomgr.h
@@ -1,31 +1,23 @@
 #pragma once
-#include <vector>
-#include <queue>
+#include <deque>
+#include <string>
 #include <CEntity.h>
+#include <CVector.h>
 
-using StreamHandle = int;
-
-enum eAudioStreamState
-{
-    Stopped = -1,
-    Playing = 1,
-    Paused = 2,
-};
+using StreamHandle = uint32_t;
 
 class AudioMgr
 {
 private:
     static inline std::deque<StreamHandle> needToFree;
-    static inline std::unordered_map<std::string, StreamHandle> cache;
 
-    static StreamHandle Load(const std::string &path);
-    static void SetVolume(StreamHandle handle, float volume);
     static bool ShouldPlaySound();
     
 public:
     static void Init();
     static void ReloadConfig();
-    static void PlayFileSound(const std::string &path, CEntity *pEntity = nullptr, float volume = 1.0f, bool cached = false);
+    static void Play3DSound(const std::string &path, const CVector &worldPos, CEntity *pEntity = nullptr, float baseVolume = 1.0f, float maxDistance = 40.0f);
+    static void PlayFileSound(const std::string &path, float volume = 1.0f);
     static void PlayClickSound();
     static void PlaySwitchSound(CEntity *pEntity = nullptr);
 };


### PR DESCRIPTION
### Summary

This PR modernizes the ModelExtras audio architecture by introducing dynamic 3D positional audio with camera-relative stereo panning and linear acoustic distance falloff, adds full runtime compatibility with both CLEO 4.4.4+ and CLEO 5 BASS sound engines, synchronizes playback with the game pause menu, and implements fixed 2D cockpit audio for in-cabin switch toggles and indicators.

---

### Key Features & Technical Details

1. **Dynamic 3D Positional Audio & Natural Acoustic Falloff (`src/utils/audiomgr.cpp`):**
   - Calculates 3D distance and stereo panning dynamically using `TheCamera.GetPosition()` and camera right matrix (`TheCamera.m_mCameraMatrix.right`).
   - Implements natural smooth linear distance falloff (`distFactor = 1.0 - ratio`) with near-field full volume (up to 5m) extending realistically to 65m for engine start, 60m for air brakes, 50m for reverse beepers, and 80m for exhaust backfires.
   - Stereo panning smoothly moves sounds between left (`-1.0`) and right (`+1.0`) speakers as the camera rotates.
   - Scaled with in-game SFX master volume (`*(BYTE*)0xBA6797 / 64.0f`) and `.ini` `SoundMult`.

2. **CLEO 4.4.4+ & CLEO 5 Compatibility:**
   - Dynamically resolves BASS engine exports (`BASS_StreamCreateFile`, `BASS_ChannelPlay`, `BASS_ChannelSetAttribute`, `BASS_ChannelPause`, `BASS_ChannelFree`) from `bass.dll` / CLEO.
   - Implemented PE file version inspection (`GetFileVersionInfoA` / `VerQueryValueA`) via `version.lib` in `src/dllmain.cpp` to accurately check for minimum required CLEO 4.4.4+ runtime and alert users on outdated installations.

3. **Game Pause Menu Synchronization:**
   - Monitors `CTimer::m_UserPause` and `CTimer::m_CodePause` to automatically pause active audio channels when entering the ESC / pause menu and resume upon unpausing.

4. **Dedicated 2D Cockpit Audio (`AudioMgr::PlayFileSound`):**
   - Switch toggle clicks (`switch_toggle.wav`) and turn signal ticks (`indicator_on.wav` / `indicator_off.wav`) play directly as centered, unattenuated 2D stereo cockpit sounds while driving.

5. **Fixed Audio Loop Issue:**
   - Switched `BASS_StreamCreateFile` flags from `4` (`BASS_SAMPLE_LOOP`) to `0` (one-shot). Sounds play once and terminate cleanly.
