### PR TITLE
feat(config): make all keybindings, lights parameters and feature toggles dynamically reloadable via MERELOAD

### DIFF
--- a/src/features/core/base.cpp
+++ b/src/features/core/base.cpp
@@ -25,3 +25,10 @@ bool CBaseFeature::IsActive() const {
     if (gConfig.ReadBoolean("FEATURES", m_name, false)) return true;
     return false;
 }
+
+void CBaseFeature::ReloadConfig() {
+    m_bActive = IsActive();
+    if (m_featureId <= eFeatureMatrix::FeatureCount) {
+        ModelExtras::m_bEnabledFeatures.set(static_cast<int>(m_featureId), m_bActive);
+    }
+}

--- a/src/features/core/base.h
+++ b/src/features/core/base.h
@@ -28,6 +28,7 @@ public:
 
   virtual void Init() = 0;
   virtual void Shutdown() {}
+  virtual void ReloadConfig();
   virtual void Reload() {}
   virtual void Reload(CVehicle *pVeh) {}
 };

--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -71,6 +71,15 @@ inline float GetZAngleForPoint(CVector2D const &point)
 bool gbLightPointLights = true;
 bool gbSirenPointLights = true;
 
+static uint32_t g_nFogLightKey = VK_J;
+static uint32_t g_nLongLightKey = VK_G;
+static uint32_t g_nIndicatorNoneKey = VK_SHIFT;
+static uint32_t g_nIndicatorLeftKey = VK_Z;
+static uint32_t g_nIndicatorRightKey = VK_C;
+static uint32_t g_nIndicatorBothKey = VK_X;
+static bool g_bFoglightTiedToHeadlight = true;
+static bool g_bAutoIndicatorsOnSteer = false;
+
 void Lights::InitConfig()
 {
 	gbGlobalIndicatorLights = gConfig.ReadBoolean("LIGHTS", "StandardLights_GlobalIndicatorLights", gConfig.ReadBoolean("FEATURES", "StandardLights_GlobalIndicatorLights", false));
@@ -83,6 +92,16 @@ void Lights::InitConfig()
 	gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 250));
 	gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.8f));
 	gTailLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "TailLightCoronaIntensity", gConfig.ReadInteger("VISUAL", "TailLightCoronaIntensity", 60));
+
+	g_nFogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", VK_J);
+	g_nLongLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", VK_G);
+	g_nIndicatorNoneKey = gConfig.ReadInteger("KEYS", "IndicatorLightNoneKey", VK_SHIFT);
+	g_nIndicatorLeftKey = gConfig.ReadInteger("KEYS", "IndicatorLightLeftKey", VK_Z);
+	g_nIndicatorRightKey = gConfig.ReadInteger("KEYS", "IndicatorLightRightKey", VK_C);
+	g_nIndicatorBothKey = gConfig.ReadInteger("KEYS", "IndicatorLightBothKey", VK_X);
+
+	g_bFoglightTiedToHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true));
+	g_bAutoIndicatorsOnSteer = gConfig.ReadBoolean("LIGHTS", "AutoIndicatorsOnSteer", false);
 }
 void Lights::Init()
 {
@@ -413,12 +432,9 @@ void Lights::Init()
 		if (pVeh && pVeh->IsDriver(FindPlayerPed()) && !Util::IsEngineOff(pVeh))
 		{
 			static size_t prev = 0;
-			static uint32_t fogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", VK_J);
-
-			static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true));
 			bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
-			bool canToggleFogLight = !foglightTiedtoHeadlight || isHeadlightsActive;
-			if (Util::IsKeyPressed(fogLightKey) && IsMatAvail(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight)
+			bool canToggleFogLight = !g_bFoglightTiedToHeadlight || isHeadlightsActive;
+			if (Util::IsKeyPressed(g_nFogLightKey) && IsMatAvail(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight)
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
 				if (now - prev > 500.0f)
@@ -430,10 +446,9 @@ void Lights::Init()
 				}
 			}
 
-			static uint32_t longLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", VK_G);
 			bool isHeadlightsActiveForLong = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime() || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
 			bool canToggleLongLights = !(gbProperShadersDetected && !gbLightPointLights);
-			if (Util::IsKeyPressed(longLightKey) && isHeadlightsActiveForLong && canToggleLongLights)
+			if (Util::IsKeyPressed(g_nLongLightKey) && isHeadlightsActiveForLong && canToggleLongLights)
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
 				if (now - prev > 500.0f)
@@ -688,35 +703,29 @@ void Lights::Init()
 			if (pControlVeh->m_pDriver == FindPlayerPed() &&
 				(pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_BIKE || pControlVeh->m_nVehicleSubClass == VEHICLE_QUAD || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK))
 			{
-				static uint32_t indicatorNoneKey = gConfig.ReadInteger("KEYS", "IndicatorLightNoneKey", VK_SHIFT);
-				static uint32_t indicatorLeftKey = gConfig.ReadInteger("KEYS", "IndicatorLightLeftKey", VK_Z);
-				static uint32_t indicatorRightKey = gConfig.ReadInteger("KEYS", "IndicatorLightRightKey", VK_C);
-				static uint32_t indicatorBothKey = gConfig.ReadInteger("KEYS", "IndicatorLightBothKey", VK_X);
-
-				if (Util::IsKeyPressed(indicatorNoneKey))
+				if (Util::IsKeyPressed(g_nIndicatorNoneKey))
 				{
 					data.m_nIndicatorState = eIndicatorState::Off;
 					delay = 0;
 					indicatorsDelay = false;
 				}
 
-				if (Util::IsKeyPressed(indicatorLeftKey))
+				if (Util::IsKeyPressed(g_nIndicatorLeftKey))
 				{
 					data.m_nIndicatorState = eIndicatorState::LeftOn;
 				}
 
-				if (Util::IsKeyPressed(indicatorRightKey))
+				if (Util::IsKeyPressed(g_nIndicatorRightKey))
 				{
 					data.m_nIndicatorState = eIndicatorState::RightOn;
 				}
 
-				if (Util::IsKeyPressed(indicatorBothKey))
+				if (Util::IsKeyPressed(g_nIndicatorBothKey))
 				{
 					data.m_nIndicatorState = eIndicatorState::BothOn;
 				}
 
-				static bool bAutoIndicatorsOnSteer = gConfig.ReadBoolean("LIGHTS", "AutoIndicatorsOnSteer", gConfig.ReadBoolean("TWEAKS", "AutoIndicatorsOnSteer", false));
-				if (bAutoIndicatorsOnSteer && data.m_nIndicatorState != eIndicatorState::BothOn)
+				if (g_bAutoIndicatorsOnSteer && data.m_nIndicatorState != eIndicatorState::BothOn)
 				{
 					static bool bWasAutoSteerActive = false;
 					bool bSteerLeft = (pControlVeh->m_fSteerAngle > 0.08f) || Util::IsKeyPressed('A') || Util::IsKeyPressed(VK_LEFT);

--- a/src/features/lights/components/fog_light.cpp
+++ b/src/features/lights/components/fog_light.cpp
@@ -33,13 +33,10 @@ bool FogLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
 void FogLightComponent::Process(CVehicle* pVeh, VehLightData& data) {
     if (pVeh->m_pDriver == FindPlayerPed() && !Util::IsEngineOff(pVeh)) {
         static size_t prev = 0;
-        static uint32_t fogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", VK_J);
-        static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true));
-
         bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
-        bool canToggleFogLight = !foglightTiedtoHeadlight || isHeadlightsActive;
+        bool canToggleFogLight = !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
 
-        if (Util::IsKeyPressed(fogLightKey) && LightManager::IsMaterialAvailable(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight) {
+        if (Util::IsKeyPressed(LightsConfig::Get().nFogLightKey) && LightManager::IsMaterialAvailable(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight) {
             size_t now = CTimer::m_snTimeInMilliseconds;
             if (now - prev > 500.0f) {
                 data.bFogLightsOn = !data.bFogLightsOn;
@@ -51,9 +48,8 @@ void FogLightComponent::Process(CVehicle* pVeh, VehLightData& data) {
 }
 
 void FogLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
-    static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true));
     bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
-    bool shouldRenderFog = !foglightTiedtoHeadlight || isHeadlightsActive;
+    bool shouldRenderFog = !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
 
     if (!data.bFogLightsOn || !shouldRenderFog) return;
     bool isFogOk = !Util::IsPanelDamaged(pControlVeh, ePanels::BUMP_FRONT);

--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -45,10 +45,9 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
     if (pVeh->m_pDriver == FindPlayerPed() && !Util::IsEngineOff(pVeh)) {
         static size_t prev = 0;
-        static uint32_t longLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", VK_G);
         bool isHeadlightsActiveForLong = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime() || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
         bool canToggleLongLights = !(gbProperShadersDetected && !LightsConfig::Get().gbLightPointLights);
-        if (Util::IsKeyPressed(longLightKey) && isHeadlightsActiveForLong && canToggleLongLights) {
+        if (Util::IsKeyPressed(LightsConfig::Get().nLongLightKey) && isHeadlightsActiveForLong && canToggleLongLights) {
             size_t now = CTimer::m_snTimeInMilliseconds;
             if (now - prev > 500.0f) {
                 data.bLongLightsOn = !data.bLongLightsOn;

--- a/src/features/lights/components/indicator.cpp
+++ b/src/features/lights/components/indicator.cpp
@@ -94,24 +94,18 @@ void IndicatorComponent::Process(CVehicle* pVeh, VehLightData& data) {
     if (pVeh->m_pDriver == FindPlayerPed() &&
         (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_BIKE || pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK))
     {
-        static uint32_t indicatorNoneKey = gConfig.ReadInteger("KEYS", "IndicatorLightNoneKey", VK_SHIFT);
-        static uint32_t indicatorLeftKey = gConfig.ReadInteger("KEYS", "IndicatorLightLeftKey", VK_Z);
-        static uint32_t indicatorRightKey = gConfig.ReadInteger("KEYS", "IndicatorLightRightKey", VK_C);
-        static uint32_t indicatorBothKey = gConfig.ReadInteger("KEYS", "IndicatorLightBothKey", VK_X);
-
-        if (Util::IsKeyPressed(indicatorNoneKey)) {
+        if (Util::IsKeyPressed(LightsConfig::Get().nIndicatorNoneKey)) {
             data.nIndicatorState = eIndicatorState::Off;
             BlinkerState::Get().Reset();
-        } else if (Util::IsKeyPressed(indicatorLeftKey)) {
+        } else if (Util::IsKeyPressed(LightsConfig::Get().nIndicatorLeftKey)) {
             data.nIndicatorState = eIndicatorState::LeftOn;
-        } else if (Util::IsKeyPressed(indicatorRightKey)) {
+        } else if (Util::IsKeyPressed(LightsConfig::Get().nIndicatorRightKey)) {
             data.nIndicatorState = eIndicatorState::RightOn;
-        } else if (Util::IsKeyPressed(indicatorBothKey)) {
+        } else if (Util::IsKeyPressed(LightsConfig::Get().nIndicatorBothKey)) {
             data.nIndicatorState = eIndicatorState::BothOn;
         }
 
-        static bool bAutoIndicatorsOnSteer = gConfig.ReadBoolean("LIGHTS", "AutoIndicatorsOnSteer", gConfig.ReadBoolean("TWEAKS", "AutoIndicatorsOnSteer", false));
-        if (bAutoIndicatorsOnSteer && data.nIndicatorState != eIndicatorState::BothOn) {
+        if (LightsConfig::Get().bAutoIndicatorsOnSteer && data.nIndicatorState != eIndicatorState::BothOn) {
             bool bSteerLeft = (pVeh->m_fSteerAngle > 0.08f) || Util::IsKeyPressed('A') || Util::IsKeyPressed(VK_LEFT);
             bool bSteerRight = (pVeh->m_fSteerAngle < -0.08f) || Util::IsKeyPressed('D') || Util::IsKeyPressed(VK_RIGHT);
 

--- a/src/features/lights/data.h
+++ b/src/features/lights/data.h
@@ -20,11 +20,20 @@ struct LightsConfig {
     bool gbSirenPointLights = true;
 
     float gfGlobalCoronaSize = 0.3f;
-    int gGlobalCoronaIntensity = 250;
-    int gGlobalShadowIntensity = 220;
+    int gGlobalCoronaIntensity = 50;
+    int gGlobalShadowIntensity = 50;
     float gfTailLightCoronaSize = 0.8f;
     int gTailLightCoronaIntensity = 60;
     float headlightSz = 5.0f;
+
+    uint32_t nFogLightKey = 'J';
+    uint32_t nLongLightKey = 'G';
+    uint32_t nIndicatorNoneKey = VK_SHIFT;
+    uint32_t nIndicatorLeftKey = 'Z';
+    uint32_t nIndicatorRightKey = 'C';
+    uint32_t nIndicatorBothKey = 'X';
+    bool bAutoIndicatorsOnSteer = false;
+    bool bFoglightTiedToHeadlight = false;
 
     void InitConfig() {
         gbGlobalIndicatorLights = gConfig.ReadBoolean("LIGHTS", "StandardLights_GlobalIndicatorLights", gConfig.ReadBoolean("FEATURES", "StandardLights_GlobalIndicatorLights", false));
@@ -33,10 +42,19 @@ struct LightsConfig {
         gbSirenPointLights = gConfig.ReadBoolean("LIGHTS", "SirenPointLights", gConfig.ReadBoolean("FEATURES", "SirenPointLights", true));
 
         gfGlobalCoronaSize = gConfig.ReadFloat("LIGHTS", "LightCoronaSize", gConfig.ReadFloat("VISUAL", "LightCoronaSize", 0.3f));
-        gGlobalShadowIntensity = gConfig.ReadInteger("LIGHTS", "LightShadowIntensity", gConfig.ReadInteger("VISUAL", "LightShadowIntensity", 220));
-        gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 250));
+        gGlobalShadowIntensity = gConfig.ReadInteger("LIGHTS", "LightShadowIntensity", gConfig.ReadInteger("VISUAL", "LightShadowIntensity", 50));
+        gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 50));
         gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.8f));
         gTailLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "TailLightCoronaIntensity", gConfig.ReadInteger("VISUAL", "TailLightCoronaIntensity", 60));
+
+        nFogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", 'J');
+        nLongLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", 'G');
+        nIndicatorNoneKey = gConfig.ReadInteger("KEYS", "IndicatorLightNoneKey", VK_SHIFT);
+        nIndicatorLeftKey = gConfig.ReadInteger("KEYS", "IndicatorLightLeftKey", 'Z');
+        nIndicatorRightKey = gConfig.ReadInteger("KEYS", "IndicatorLightRightKey", 'C');
+        nIndicatorBothKey = gConfig.ReadInteger("KEYS", "IndicatorLightBothKey", 'X');
+        bAutoIndicatorsOnSteer = gConfig.ReadBoolean("LIGHTS", "AutoIndicatorsOnSteer", gConfig.ReadBoolean("TWEAKS", "AutoIndicatorsOnSteer", false));
+        bFoglightTiedToHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", false));
     }
 
 private:

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -76,6 +76,12 @@ void LightsFeature::Init() {
 	});
 }
 
+void LightsFeature::ReloadConfig() {
+	CBaseFeature::ReloadConfig();
+	LightsConfig::Get().InitConfig();
+}
+
 void LightsFeature::Reload(CVehicle* pVeh) {
+	ReloadConfig();
 	LightManager::Reload(pVeh);
 }

--- a/src/features/lights/lights.h
+++ b/src/features/lights/lights.h
@@ -7,5 +7,6 @@ protected:
 
 public:
     LightsFeature() : CBaseFeature("StandardLightsv2", "FEATURES", eFeatureMatrix::StandardLights) {}
+    void ReloadConfig() override;
     void Reload(CVehicle* pVeh) override;
 };

--- a/src/features/rollbackbed.cpp
+++ b/src/features/rollbackbed.cpp
@@ -70,8 +70,22 @@ bool RollbackBed::UpdateMove(HydraulicPiston &piston, float moveSpeed, bool bExp
     return false;
 }
 
+static uint32_t g_nRollbackBedToggleKey = 'K';
+
+void RollbackBed::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    g_nRollbackBedToggleKey = gConfig.ReadInteger("KEYS", "RollbackBedToggleKey", 'K');
+}
+
+void RollbackBed::Reload(CVehicle *pVeh)
+{
+    ReloadConfig();
+}
+
 void RollbackBed::Init()
 {
+    ReloadConfig();
     ModelInfoMgr::RegisterDummy([](CVehicle *pVeh, RwFrame *pFrame, const std::string_view nodeName)
     {
         if (!nodeName.starts_with("x_rb"))
@@ -163,9 +177,8 @@ void RollbackBed::Init()
     {
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
-        static uint32_t toggleKey = gConfig.ReadInteger("KEYS", "RollbackBedToggleKey", 'K');
 
-        if (Util::IsKeyPressed(toggleKey) && now - prev > 500.0f)
+        if (Util::IsKeyPressed(g_nRollbackBedToggleKey) && now - prev > 500.0f)
         {
             CVehicle *pVeh = FindPlayerVehicle();
             if (pVeh)

--- a/src/features/rollbackbed.h
+++ b/src/features/rollbackbed.h
@@ -48,4 +48,6 @@ protected:
 
 public:
     RollbackBed() : CVehFeature<RollbackBedData>("RollbackBed", "FEATURES", eFeatureMatrix::RollbackBed) {}
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override;
 };

--- a/src/features/roof.cpp
+++ b/src/features/roof.cpp
@@ -33,8 +33,22 @@ bool ConvertibleRoof::UpdateRotation(RoofConfig &config, CVehicle *pVeh, bool cl
     return false;
 }
 
+static uint32_t g_nRoofToggleKey = 'T';
+
+void ConvertibleRoof::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    g_nRoofToggleKey = gConfig.ReadInteger("KEYS", "RoofToggleKey", 'T');
+}
+
+void ConvertibleRoof::Reload(CVehicle *pVeh)
+{
+    ReloadConfig();
+}
+
 void ConvertibleRoof::Init()
 {
+    ReloadConfig();
     ModelInfoMgr::RegisterDummy([](CVehicle *pVeh, RwFrame *pFrame, const std::string_view nodeName)
     {
         bool isBoot = nodeName.starts_with("x_convertible_boot");
@@ -151,9 +165,8 @@ void ConvertibleRoof::Init()
     {
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
-        static uint32_t roofToggleKey = gConfig.ReadInteger("KEYS", "RoofToggleKey", 'T');
 
-        if (Util::IsKeyPressed(roofToggleKey) && now - prev > 500.0f)
+        if (Util::IsKeyPressed(g_nRoofToggleKey) && now - prev > 500.0f)
         {
             CVehicle *pVeh = FindPlayerVehicle();
             if (pVeh)

--- a/src/features/roof.h
+++ b/src/features/roof.h
@@ -42,6 +42,9 @@ protected:
 public:
     ConvertibleRoof() : CVehFeature<RoofData>("ConvertibleRoof", "FEATURES", eFeatureMatrix::ConvertibleRoof) {}
 
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override;
+
     static bool IsRoofOpen(CVehicle *pVeh) {
         return m_VehData.Get(pVeh).m_bRoofTargetExpanded;
     }

--- a/src/features/sirens.cpp
+++ b/src/features/sirens.cpp
@@ -60,9 +60,20 @@ bool Sirens::hkUsesSiren(std::function<hkUsesSirenFunc> originalCall, CVehicle* 
 
 static ThiscallEvent<AddressList<0x6AAB71, H_CALL>, PRIORITY_BEFORE, ArgPickN<CVehicle*, 0>, void(CVehicle*)> Automobile__PreRenderEvent;
 static CVehicle *pCurrentVeh = nullptr;
+static uint32_t g_nSirenKey = VK_L;
+
+void Sirens::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	g_nSirenKey = gConfig.ReadInteger("KEYS", "SirenLightKey", VK_L);
+}
 
 void Sirens::Reload(CVehicle *pVeh)
 {
+	ReloadConfig();
+	if (!pVeh) {
+		return;
+	}
 	int model = pVeh->m_nModelIndex;
 	modelRotators.erase(model);
 	auto itModel = modelData.find(model);
@@ -708,8 +719,7 @@ void Sirens::Init()
 
 		if (now - prev > 300.0f)
 		{
-			static uint32_t sirenKey = gConfig.ReadInteger("KEYS", "SirenLightKey", VK_L);
-			if (Util::IsKeyPressed(sirenKey))
+			if (Util::IsKeyPressed(g_nSirenKey))
 			{
 				int model = vehicle->m_nModelIndex;
 

--- a/src/features/sirens.h
+++ b/src/features/sirens.h
@@ -229,6 +229,7 @@ public:
     static inline int CurrentModel = -1;
 
     static void Parse(const nlohmann::json &data, int model);
+    void ReloadConfig() override;
     void Reload(CVehicle* pVeh) override;
     friend int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat);
 

--- a/src/features/spotlights.cpp
+++ b/src/features/spotlights.cpp
@@ -81,6 +81,19 @@ bool SpotLights::IsEnabled(CVehicle *pVeh)
 	return m_VehData.Get(pVeh).bEnabled;
 }
 
+static uint32_t g_nSpotLightKey = VK_B;
+
+void SpotLights::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	g_nSpotLightKey = gConfig.ReadInteger("KEYS", "SpotLightKey", VK_B);
+}
+
+void SpotLights::Reload(CVehicle *pVeh)
+{
+	ReloadConfig();
+}
+
 void SpotLights::OnHudRender()
 {
 	CVehicle *pVeh = FindPlayerVehicle(-1, false);
@@ -96,8 +109,7 @@ void SpotLights::OnHudRender()
 	}
 
 	static size_t prev = 0;
-	static uint32_t key = gConfig.ReadInteger("KEYS", "SpotLightKey", VK_B);
-	if (Util::IsKeyPressed(key))
+	if (Util::IsKeyPressed(g_nSpotLightKey))
 	{
 		size_t now = CTimer::m_snTimeInMilliseconds;
 		if (now - prev > 500.0f)

--- a/src/features/spotlights.h
+++ b/src/features/spotlights.h
@@ -31,4 +31,6 @@ public:
 public:
     SpotLights() : CVehFeature<SpotlightData>("SpotLights", "FEATURES", eFeatureMatrix::StandardLights) {}
 	static bool IsEnabled(CVehicle *pVeh);
+	void ReloadConfig() override;
+	void Reload(CVehicle *pVeh) override;
 };

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -145,6 +145,7 @@ void ModelExtras::Reload(CVehicle *pVeh)
     AudioMgr::ReloadConfig();
     for (const auto &pFeature : m_Features) {
         if (pFeature) {
+            pFeature->ReloadConfig();
             pFeature->Reload(pVeh);
         }
     }


### PR DESCRIPTION
### Summary of Changes

- **Root Cause:** In previous versions, feature toggles in `[FEATURES]` and keybindings in `[KEYS]` (e.g., `FogLightKey`, `IndicatorLight*Key`, `LongLightKey`, `RollbackBedToggleKey`, `RoofToggleKey`, `SirenLightKey`, `SpotLightKey`) were either read once in constructors or cached inside `static` local variables. As a result, changing these settings in `ModelExtras.ini` during runtime and executing `MERELOAD` had no effect.
- **Dynamic Reload Architecture:**
  - Added `CBaseFeature::ReloadConfig()` virtual method to reload `m_bActive` and update `ModelExtras::m_bEnabledFeatures` dynamically without restarting the game.
  - Replaced all local `static uint32_t` keybindings across `Lights`, `Sirens`, `SpotLights`, `ConvertibleRoof`, and `RollbackBed` with dynamically reloadable configuration variables refreshed on `MERELOAD`.
  - Added missing `[LIGHTS]` parameters (`FoglightTiedToHeadlight`, `AutoIndicatorsOnSteer`, etc.) to `Lights::InitConfig()`.
- **Impact:** Allows developers and players to live-reload all feature switches, keybindings, and lighting parameters instantly in-game via `MERELOAD`.