### PR TITLE
feat(lights): enhance non-adapted taillight material brightness and corona scaling on braking

### DIFF
--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -138,6 +138,25 @@ void Lights::Init()
 				return { CRGBA(190, 190, 190, 255), DEFAULT_MAT_COL };
 			}
 		}
+		if (type == eMaterialType::TailLightLeft || type == eMaterialType::TailLightRight)
+		{
+			if (pVeh)
+			{
+				bool hasDedicatedBrake = IsMatAvail(pVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
+				if (!hasDedicatedBrake)
+				{
+					bool isBraking = (pVeh->m_fBreakPedal > 0.05f) && (pVeh->m_pDriver != nullptr);
+					if (isBraking)
+					{
+						return { CRGBA(255, 255, 255, 255), DEFAULT_MAT_COL };
+					}
+					else
+					{
+						return { CRGBA(180, 180, 180, 255), DEFAULT_MAT_COL };
+					}
+				}
+			}
+		}
 		return { DEFAULT_MAT_COL, DEFAULT_MAT_COL };
 	});
 
@@ -608,10 +627,10 @@ void Lights::Init()
 					}
 					else if (IsMatAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
 						if (isLeftRearOk) {
-							RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightLeft, true, shdwName, shdwSz, false, isLeftRearOk);
+							RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightLeft, true, shdwName, shdwSz, true, isLeftRearOk);
 						}
 						if (isRightRearOk) {
-							RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightRight, true, shdwName, shdwSz, false, isRightRearOk);
+							RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightRight, true, shdwName, shdwSz, true, isRightRearOk);
 						}
 					}
 				}
@@ -640,13 +659,18 @@ void Lights::Init()
 					}
 				}
 				else {
+					bool hasDedicatedBrake = IsMatAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight}) ||
+					                         IsDummyAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
+					bool isBraking = (pControlVeh->m_fBreakPedal > 0.05f) && (pControlVeh->m_pDriver != nullptr);
+					bool tailHighlight = !hasDedicatedBrake && isBraking;
+
 					auto tailLightsRender = [&](bool leftOk, bool rightOk) {
 						if (IsMatAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight}) || IsDummyAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
 							if (leftOk) {
-								RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightLeft, true, shdwName, shdwSz, false, leftOk);
+								RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightLeft, true, shdwName, shdwSz, tailHighlight, leftOk);
 							}
 							if (rightOk) {
-								RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightRight, true, shdwName, shdwSz, false, rightOk);
+								RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightRight, true, shdwName, shdwSz, tailHighlight, rightOk);
 							}
 						} else if (IsMatAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight}) || IsDummyAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight})) {
 							if (leftOk) {
@@ -859,7 +883,12 @@ void Lights::RenderLight(CVehicle *pVeh, eMaterialType state, bool shadows, std:
 				continue;
 			}
 
-			EnableDummy((int)pVeh + 42 + id++, e, pVeh, highlight ? 3.00f : 1.0f);
+			float szMul = 1.0f;
+			if (highlight)
+			{
+				szMul = (state == eMaterialType::TailLightLeft || state == eMaterialType::TailLightRight) ? 1.50f : 3.00f;
+			}
+			EnableDummy((int)pVeh + 42 + id++, e, pVeh, szMul);
 
 			// Skip front shadows on bike wheelie
 			if (c.dummyPos == eDummyPos::Front && Util::IsVehicleDoingWheelie(pVeh))

--- a/src/features/lights/components/brake_light.cpp
+++ b/src/features/lights/components/brake_light.cpp
@@ -55,10 +55,10 @@ void BrakeLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, Veh
                     }
                 } else if (LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight}) || LightManager::IsDummyAvailable(data, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
                     if (isLeftRearOk) {
-                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightLeft, true, shdwName, shdwSz, false, isLeftRearOk);
+                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightLeft, true, shdwName, shdwSz, true, isLeftRearOk);
                     }
                     if (isRightRearOk) {
-                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightRight, true, shdwName, shdwSz, false, isRightRearOk);
+                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightRight, true, shdwName, shdwSz, true, isRightRearOk);
                     }
                 }
             }

--- a/src/features/lights/components/tail_light.cpp
+++ b/src/features/lights/components/tail_light.cpp
@@ -58,13 +58,18 @@ void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
         bool sttInstalled = LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
 
         if ((tailLightFlag || indicatorOn) && !sttInstalled) {
+            bool hasDedicatedBrake = LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight}) ||
+                                     LightManager::IsDummyAvailable(data, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
+            bool isBraking = (pControlVeh->m_fBreakPedal > 0.05f) && (pControlVeh->m_pDriver != nullptr);
+            bool tailHighlight = !hasDedicatedBrake && isBraking;
+
             auto tailLightsRender = [&](bool leftOk, bool rightOk) {
                 if (LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight}) || LightManager::IsDummyAvailable(data, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
                     if (leftOk) {
-                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightLeft, true, shdwName, shdwSz, false, leftOk);
+                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightLeft, true, shdwName, shdwSz, tailHighlight, leftOk);
                     }
                     if (rightOk) {
-                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightRight, true, shdwName, shdwSz, false, rightOk);
+                        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::TailLightRight, true, shdwName, shdwSz, tailHighlight, rightOk);
                     }
                 } else if (LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight}) || LightManager::IsDummyAvailable(data, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight})) {
                     if (leftOk) {

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "manager.h"
 #include "utils/modelinfomgr.h"
 #include "utils/render.h"
@@ -47,6 +47,19 @@ void LightManager::Init() {
                 return { CRGBA(255, 255, 255, 255), DEFAULT_MAT_COL };
             } else {
                 return { CRGBA(190, 190, 190, 255), DEFAULT_MAT_COL };
+            }
+        }
+        if (type == eMaterialType::TailLightLeft || type == eMaterialType::TailLightRight) {
+            if (pVeh) {
+                bool hasDedicatedBrake = LightManager::IsMaterialAvailable(pVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
+                if (!hasDedicatedBrake) {
+                    bool isBraking = (pVeh->m_fBreakPedal > 0.05f) && (pVeh->m_pDriver != nullptr);
+                    if (isBraking) {
+                        return { CRGBA(255, 255, 255, 255), DEFAULT_MAT_COL };
+                    } else {
+                        return { CRGBA(180, 180, 180, 255), DEFAULT_MAT_COL };
+                    }
+                }
             }
         }
         return { DEFAULT_MAT_COL, DEFAULT_MAT_COL };
@@ -176,7 +189,11 @@ void LightManager::RenderLight(CVehicle* pVeh, VehLightData& data, eMaterialType
                 continue;
             }
 
-            EnableDummy((int)pVeh + 42 + id++, dummy, pVeh, highlight ? 3.00f : 1.0f);
+            float szMul = 1.0f;
+            if (highlight) {
+                szMul = (type == eMaterialType::TailLightLeft || type == eMaterialType::TailLightRight) ? 1.50f : 3.00f;
+            }
+            EnableDummy((int)pVeh + 42 + id++, dummy, pVeh, szMul);
 
             // Skip front shadows on bike wheelie
             if (c.dummyPos == eDummyPos::Front && Util::IsVehicleDoingWheelie(pVeh)) {


### PR DESCRIPTION
### Summary of Changes

- **Problem:** On vanilla/non-adapted vehicles (vehicles without dedicated `BrakeLightLeft/Right`, `NABrakeLight`, or `STTLight` materials), when braking while taillights are already illuminated (at night or with headlights on), only the ground shadow was darkening, but neither the taillight material ambient brightness nor the light corona size changed to indicate braking.
- **Solution:**
  - In `ModelInfoMgr::RegisterMaterialColProvider`, when braking on vehicles without dedicated brake lights, taillight material brightness is dynamically boosted to 100% full intensity (`CRGBA(255, 255, 255, 255)`), whereas normal taillights stay at subtle ambient glow (`CRGBA(180, 180, 180, 255)`).
  - Taillight corona size is scaled by `+50%` (`1.50f` multiplier) during braking when no dedicated brake lights are present, providing a clear and realistic visual brake cue.
  - Vehicles with dedicated brake light materials remain completely unaffected and retain their custom behavior.