### PR TITLE
fix(core): enable dynamic live-reload and runtime toggle support across all features

### DIFF
--- a/src/features/backfire.cpp
+++ b/src/features/backfire.cpp
@@ -98,13 +98,22 @@ void BackFireEffect::BackFireMulti(CVehicle *pVeh)
 std::vector<int> ValidModels = {};
 bool onlySelected = false;
 
+void BackFireEffect::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    std::string line = gConfig.ReadString("TABLE", "BackFireEffect_VehicleModels", "");
+    onlySelected = gConfig.ReadBoolean("FEATURES", "BackfireEffect_OnlySelectedModels", true);
+    ValidModels.clear();
+    Util::GetModelsFromIni(line, ValidModels);
+}
+
 void BackFireEffect::Init()
 {
-    Events::initGameEvent += []()
+    ReloadConfig();
+
+    Events::initGameEvent += [this]()
     {
-        std::string line = gConfig.ReadString("TABLE", "BackFireEffect_VehicleModels", "");
-        onlySelected = gConfig.ReadBoolean("FEATURES", "BackfireEffect_OnlySelectedModels", true);
-        Util::GetModelsFromIni(line, ValidModels);
+        ReloadConfig();
     };
 
     Events::vehicleRenderEvent.before += [](CVehicle *vehicle)
@@ -116,6 +125,11 @@ void BackFireEffect::Init()
 // Inspired by Junior's https://www.mixmods.com.br/2016/06/backfire-als-v2-5-mod-estalar-escapamento/
 void BackFireEffect::Process(CVehicle *pVeh)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::BackfireEffect))
+    {
+        return;
+    }
+
     if (!pVeh->GetIsOnScreen() || pVeh->bEngineBroken || !pVeh->bEngineOn || pVeh->bIsBig || pVeh->bIsVan || pVeh->bIsBus || pVeh->bIsRCVehicle)
     {
         return;

--- a/src/features/backfire.h
+++ b/src/features/backfire.h
@@ -16,6 +16,8 @@ class BackFireEffect : public CVehFeature<BackfireData>
 {
 protected:
   void Init() override;
+  void ReloadConfig() override;
+  void Reload(CVehicle *pVeh) override { ReloadConfig(); }
   static void BackFireFX(CVehicle *pVeh, float x, float y, float z, float dirX = 0.0f, float dirY = -25.0f, float dirZ = 0.0f);
   static void BackFireSingle(CVehicle *pVeh);
   static void BackFireMulti(CVehicle *pVeh);

--- a/src/features/carcols.cpp
+++ b/src/features/carcols.cpp
@@ -10,9 +10,15 @@
      (type.g == VEHCOL.g) &&        \
      (type.b == VEHCOL.b))
 
+void Carcols::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void Carcols::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
 }
 
 bool Carcols::GetColor(CVehicle *pVeh, RpMaterial *pMat, CRGBA &col)

--- a/src/features/carcols.h
+++ b/src/features/carcols.h
@@ -30,6 +30,8 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
     Carcols() : CVehFeature<CarcolsData>("Carcols", "FEATURES", eFeatureMatrix::IVFCarcols) {}

--- a/src/features/chain.cpp
+++ b/src/features/chain.cpp
@@ -17,6 +17,9 @@ void ChainFeature::Init() {
   });
 
   ModelInfoMgr::RegisterRender([](CVehicle *pVeh) {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedChain)) {
+      return;
+    }
     if (!pVeh || !pVeh->GetIsOnScreen()) {
       return;
     }

--- a/src/features/clock.cpp
+++ b/src/features/clock.cpp
@@ -73,6 +73,7 @@ void DigitalClockFeature::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::Clock)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/core/base.cpp
+++ b/src/features/core/base.cpp
@@ -9,11 +9,11 @@ extern CIniReader gConfig;
 CBaseFeature::CBaseFeature(std::string name, std::string configSection, eFeatureMatrix featureId)
     : m_name(std::move(name)), m_configSection(std::move(configSection)), m_featureId(featureId) 
 {
-    if (IsActive()) {
-        m_bActive = true;
-        if (m_featureId <= eFeatureMatrix::FeatureCount) {
-            ModelExtras::m_bEnabledFeatures.set(static_cast<int>(m_featureId));
-        }
+    m_bActive = IsActive();
+    if (m_featureId <= eFeatureMatrix::FeatureCount) {
+        ModelExtras::m_bEnabledFeatures.set(static_cast<int>(m_featureId), m_bActive);
+    }
+    if (m_bActive) {
         LOG(INFO) << std::format("Feature '{}' enabled.", m_name);
     }
 }
@@ -23,6 +23,13 @@ bool CBaseFeature::IsActive() const {
     if (gConfig.ReadBoolean("LIGHTS", m_name, false)) return true;
     if (gConfig.ReadBoolean("SOUND", m_name, false)) return true;
     if (gConfig.ReadBoolean("FEATURES", m_name, false)) return true;
+    return false;
+}
+
+bool CBaseFeature::IsEnabled(eFeatureMatrix featureId) {
+    if (static_cast<size_t>(featureId) < ModelExtras::m_bEnabledFeatures.size()) {
+        return ModelExtras::m_bEnabledFeatures.test(static_cast<size_t>(featureId));
+    }
     return false;
 }
 

--- a/src/features/core/base.h
+++ b/src/features/core/base.h
@@ -25,6 +25,8 @@ public:
   virtual ~CBaseFeature() = default;
 
   [[nodiscard]] bool IsActive() const;
+  [[nodiscard]] bool IsActiveCached() const { return m_bActive; }
+  static bool IsEnabled(eFeatureMatrix featureId);
 
   virtual void Init() = 0;
   virtual void Shutdown() {}

--- a/src/features/dirtfx.cpp
+++ b/src/features/dirtfx.cpp
@@ -11,9 +11,15 @@ using namespace plugin;
 static CdeclEvent<AddressList<0x53CA75, H_CALL, 0x53CA61, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> CCarFXRenderer__ShutdownEvent;
 static CdeclEvent<AddressList<0x5B8FFD, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> CCarFXRenderer__InitialiseDirtTextureEvent;
 
+void DirtFx::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
+}
+
 void DirtFx::Init()
 {
-	m_bEnabled = true;
+	ReloadConfig();
 	
 	if (injector::GetBranchDestination(0x6D0E7E).as_int() != 0x5D5DB0) LOG(ERROR) << "Address conflict on 0x6D0E7E";
 	patch::Nop(0x6D0E7E, 5);

--- a/src/features/dirtfx.h
+++ b/src/features/dirtfx.h
@@ -31,9 +31,10 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-	public:
     DirtFx() : CBaseFeature("DirtFX", "FEATURES", eFeatureMatrix::DirtFX) {}
 	static void ProcessTextures(CVehicle *pVeh, RpMaterial *pMat);
 };

--- a/src/features/exhaust.cpp
+++ b/src/features/exhaust.cpp
@@ -25,6 +25,10 @@ NitroFn_t ogNitro1 = nullptr, ogNitro2 = nullptr, ogNitro3 = nullptr;
 void __fastcall ExhaustFx::hkAddExhaustParticles1(CVehicle * pVeh)
 {
     if (!pVeh) return;
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx)) {
+        if (ogFunc1) ogFunc1(pVeh);
+        return;
+    }
     auto &data = m_VehData.Get(pVeh);
     if (!data.isUsed && ogFunc1) {
         ogFunc1(pVeh);
@@ -34,6 +38,10 @@ void __fastcall ExhaustFx::hkAddExhaustParticles1(CVehicle * pVeh)
 void __fastcall ExhaustFx::hkAddExhaustParticles2(CVehicle *pVeh)
 {
     if (!pVeh) return;
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx)) {
+        if (ogFunc2) ogFunc2(pVeh);
+        return;
+    }
     auto &data = m_VehData.Get(pVeh);
     if (!data.isUsed && ogFunc2) {
         ogFunc2(pVeh);
@@ -266,6 +274,10 @@ ExhaustData ExhaustFx::LoadData(CVehicle *pVeh, RwFrame *pFrame)
 
 void ExhaustFx::RenderSmokeFx(CVehicle *pVeh, const ExhaustData &info)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx))
+    {
+        return;
+    }
     if (!pVeh || !pVeh->GetIsOnScreen() || !pVeh->bEngineOn || pVeh->bEngineBroken)
     {
         return;
@@ -377,6 +389,10 @@ void ExhaustFx::RenderSmokeFx(CVehicle *pVeh, const ExhaustData &info)
 
 void ExhaustFx::RenderNitroFx(CVehicle *pVeh, float power)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx))
+    {
+        return;
+    }
     const auto &mi = CModelInfo::GetModelInfo(pVeh->m_nModelIndex);
 
     auto &data = m_VehData.Get(pVeh);

--- a/src/features/gauge.cpp
+++ b/src/features/gauge.cpp
@@ -28,6 +28,7 @@ void GearIndicator::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedGearMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehGearData &data = m_VehData.Get(pVeh);
@@ -67,6 +68,7 @@ void MileageIndicator::Init()
     });
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh) {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedOdoMeter)) return;
     if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
     VehMileageData &data = m_VehData.Get(pVeh);
@@ -139,6 +141,7 @@ void RPMGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedRpmMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehRPMData &data = m_VehData.Get(pVeh);
@@ -207,6 +210,7 @@ void SpeedGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedSpeedMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehSpeedData &data = m_VehData.Get(pVeh);
@@ -255,6 +259,7 @@ void TurboGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedTurboMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehTurboData &data = m_VehData.Get(pVeh);

--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -17,9 +17,15 @@
 #include "roof.h"
 #include "lights.h"
 
+void DashboardLEDs::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	bEnabled = m_bActive;
+}
+
 void DashboardLEDs::Init()
 {
-	bEnabled = true;
+	ReloadConfig();
 
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat){
 		if (!bEnabled) {

--- a/src/features/leds.h
+++ b/src/features/leds.h
@@ -20,8 +20,9 @@ private:
 	
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-	public:
     DashboardLEDs() : CVehFeature<VehLEDData>("DashboardLED", "FEATURES", eFeatureMatrix::DashboardLED) {}
 };

--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -110,7 +110,7 @@ void Lights::Init()
 		return;
 	}
 
-	m_bEnabled = true;
+	ReloadConfig();
 	patch::Nop(0x6E2722, 19);	  // CVehicle::DoHeadLightReflection
 	patch::SetUChar(0x6E1A22, 0); // CVehicle::DoTailLightEffect
 
@@ -994,9 +994,16 @@ void Lights::EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMu
 
 // NOT
 
+void Lights::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
+	InitConfig();
+}
+
 void Lights::Reload(CVehicle* pVeh)
 {
-	InitConfig();
+	ReloadConfig();
 	if (pVeh) {
 		auto it = m_Dummies.find(pVeh);
 		if (it != m_Dummies.end()) {

--- a/src/features/lights.h
+++ b/src/features/lights.h
@@ -60,6 +60,7 @@ public:
 	static VehLightDatav1 GetVehicleData(CVehicle *pVeh);
 
 	friend int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat);
+	void ReloadConfig() override;
 	void Reload(CVehicle* pVeh) override;
 
 	static bool GetLightState(CVehicle *pVeh, eMaterialType lightId);

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -9,6 +9,7 @@ void LightsFeature::Init() {
 		return;
 	}
 
+    ReloadConfig();
     LightManager::Init();
 
     patch::Nop(0x6E2722, 19);	  // CVehicle::DoHeadLightReflection
@@ -32,6 +33,7 @@ void LightsFeature::Init() {
 	};
 
     ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat) {
+        if (!m_bEnabled) return eMaterialType::UnknownMaterial;
         return LightManager::GetMatType(pMat); 
     });
 
@@ -41,11 +43,13 @@ void LightsFeature::Init() {
 
 	MEEvents::vehPreRenderEvent.before += [](CVehicle *pVeh)
 	{
+		if (!m_bEnabled) return;
 		LightManager::ProcessPointLights(pVeh);
 	};
 
 	Events::processScriptsEvent += []()
 	{
+		if (!m_bEnabled) return;
 		BlinkerState::Get().Update();
 
 		for (CVehicle *pVeh : CPools::ms_pVehiclePool)
@@ -61,6 +65,7 @@ void LightsFeature::Init() {
 	};
 
 	ModelInfoMgr::RegisterRender([](CVehicle *pControlVeh) {
+		if (!m_bEnabled) return;
 		int model = pControlVeh->m_nModelIndex;
 
 		if (CModelInfo::IsTrailerModel(model)) {
@@ -78,6 +83,7 @@ void LightsFeature::Init() {
 
 void LightsFeature::ReloadConfig() {
 	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
 	LightsConfig::Get().InitConfig();
 }
 

--- a/src/features/lights/lights.h
+++ b/src/features/lights/lights.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "core/base.h"
 
-class LightsFeature : public CBaseFeature{
+class LightsFeature : public CBaseFeature {
 protected:
     void Init() override;
 
 public:
-    LightsFeature() : CBaseFeature("StandardLightsv2", "FEATURES", eFeatureMatrix::StandardLights) {}
+    static inline bool m_bEnabled = false;
+    LightsFeature() : CBaseFeature("StandardLightsv2", "LIGHTS", eFeatureMatrix::REMOVED_NULL) {}
     void ReloadConfig() override;
     void Reload(CVehicle* pVeh) override;
 };

--- a/src/features/pedcols.cpp
+++ b/src/features/pedcols.cpp
@@ -96,6 +96,7 @@ void PedColors::Init() {
 	};
 
 	Events::pedRenderEvent.before += [](CPed *pPed) {
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::PedCols)) return;
 		auto &data = PedColors::m_PedData.Get(pPed);
 		if (data.m_bUsingPedCols) {
 			PedColors::m_pCurrentPed = pPed;

--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -18,9 +18,15 @@ using namespace plugin;
 
 static CVehicle *pCurrentVeh = nullptr;
 
+void LicensePlate::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void LicensePlate::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
     // RpMaterial *__cdecl CCustomCarPlateMgr::SetupMaterialPlatebackTexture(RpMaterial *material, char plateType)
     patch::PutRetn(0x6FDE50);
     patch::ReplaceFunction(0x6FD500, (void *)CCustomCarPlateMgr_Initialise);

--- a/src/features/plate.h
+++ b/src/features/plate.h
@@ -60,9 +60,10 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-  public:
     LicensePlate() : CVehFeature<PlateData>("HDLicensePlate", "FEATURES", eFeatureMatrix::HDLicensePlate) {}
   static void ProcessTextures(CVehicle *pVeh, RpMaterial *pMat);
 };

--- a/src/features/remap.cpp
+++ b/src/features/remap.cpp
@@ -7,9 +7,15 @@
 #include <rw/rpworld.h>
 #include <algorithm>
 
+void Remap::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void Remap::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
 }
 
 void Remap::LoadRemaps(CVehicle* vehicle)

--- a/src/features/remap.h
+++ b/src/features/remap.h
@@ -26,6 +26,8 @@ private:
 
 protected:
   void Init() override;
+  void ReloadConfig() override;
+  void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
   Remap() : CVehFeature<RemapVehData>("TextureRemaper", "FEATURES", eFeatureMatrix::TextureRemapper) {}

--- a/src/features/rollbackbed.cpp
+++ b/src/features/rollbackbed.cpp
@@ -152,6 +152,7 @@ void RollbackBed::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RollbackBed)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;
@@ -175,6 +176,7 @@ void RollbackBed::Init()
 
     Events::processScriptsEvent += []()
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RollbackBed)) return;
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
 

--- a/src/features/roof.cpp
+++ b/src/features/roof.cpp
@@ -91,6 +91,7 @@ void ConvertibleRoof::Init()
 
     Events::vehicleRenderEvent += [](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         bool isRainy = (CWeather::Rain > 0.05f) || (CWeather::WetRoads > 0.1f) || (CWeather::NewWeatherType == eWeatherType::WEATHER_RAINY_SF || CWeather::OldWeatherType == eWeatherType::WEATHER_RAINY_SF || CWeather::NewWeatherType == eWeatherType::WEATHER_RAINY_COUNTRYSIDE || CWeather::OldWeatherType == eWeatherType::WEATHER_RAINY_COUNTRYSIDE);
         if (!isRainy)
         {
@@ -106,6 +107,7 @@ void ConvertibleRoof::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) {
             return;
         }
@@ -165,6 +167,7 @@ void ConvertibleRoof::Init()
 
     Events::processScriptsEvent += []()
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
 

--- a/src/features/rotatedoor.cpp
+++ b/src/features/rotatedoor.cpp
@@ -66,6 +66,7 @@ void RotateDoor::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle* pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedDoors)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         RotateDoorData& data = m_VehData.Get(pVeh);

--- a/src/features/sirens.cpp
+++ b/src/features/sirens.cpp
@@ -65,6 +65,7 @@ static uint32_t g_nSirenKey = VK_L;
 void Sirens::ReloadConfig()
 {
 	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
 	g_nSirenKey = gConfig.ReadInteger("KEYS", "SirenLightKey", VK_L);
 }
 
@@ -605,7 +606,7 @@ int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat)
 
 void Sirens::Init()
 {
-	m_bEnabled = true;
+	ReloadConfig();
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat)
 								   {
 		if (!m_bEnabled) {

--- a/src/features/slidedoor.cpp
+++ b/src/features/slidedoor.cpp
@@ -60,6 +60,7 @@ void SlideDoor::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedDoors)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         SlideDoorData& data = m_VehData.Get(pVeh);

--- a/src/features/soundeffects.cpp
+++ b/src/features/soundeffects.cpp
@@ -20,6 +20,7 @@ static bool bOnlyPlayerVehicle = true;
 
 void SoundEffects::ReloadConfig()
 {
+    CBaseFeature::ReloadConfig();
     std::string line = gConfig.ReadString("TABLE", "SoundEffects_BigVehicleModels", "");
     ValidForReverseSound.clear();
     Util::GetModelsFromIni(line, ValidForReverseSound);
@@ -38,12 +39,17 @@ void SoundEffects::Reload(CVehicle *pVeh)
 
 void SoundEffects::Init()
 {
-    Events::initGameEvent += []()
+    ReloadConfig();
+
+    Events::initGameEvent += [this]()
     {
         ReloadConfig();
     };
 
     Events::processScriptsEvent += []() {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::SoundEffects)) {
+            return;
+        }
         CPed *pPlayer = FindPlayerPed();
         if (!pPlayer) {
             return;

--- a/src/features/soundeffects.h
+++ b/src/features/soundeffects.h
@@ -22,7 +22,7 @@ class SoundEffects : public CVehFeature<SoundEffectsData>
 protected:
     void Init() override;
     void Reload(CVehicle *pVeh) override;
-    static void ReloadConfig();
+    void ReloadConfig() override;
 
 public:
     SoundEffects() : CVehFeature<SoundEffectsData>("SoundEffects", "SOUND", eFeatureMatrix::SoundEffects) {}

--- a/src/features/spoiler.cpp
+++ b/src/features/spoiler.cpp
@@ -57,6 +57,10 @@ void Spoiler::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                 {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedSpoiler))
+        {
+            return;
+        }
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/spotlights.cpp
+++ b/src/features/spotlights.cpp
@@ -25,6 +25,7 @@ static inline CVector2D GetPerpRight(const CVector2D &vec)
 
 void SpotLights::Init()
 {
+	ReloadConfig();
 	ModelInfoMgr::RegisterDummy([](CVehicle *pVeh, RwFrame *pFrame, const std::string_view nodeName)
 	{
 		SpotlightData &data = m_VehData.Get(pVeh);
@@ -38,6 +39,7 @@ void SpotLights::Init()
 
 	Events::vehicleRenderEvent += [](CVehicle *pVeh)
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		if (!pVeh || !pVeh->GetIsOnScreen())
 		{
 			return;
@@ -47,11 +49,13 @@ void SpotLights::Init()
 
 	MEEvents::vehPreRenderEvent.before += [](CVehicle *pVeh)
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		ProcessPointLights(pVeh);
 	};
 
 	Events::processScriptsEvent += []()
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		for (CVehicle *pVeh : CPools::ms_pVehiclePool)
 		{
 			if (pVeh && pVeh->m_nVehicleSubClass == VEHICLE_BIKE)
@@ -63,6 +67,7 @@ void SpotLights::Init()
 
 	Events::drawingEvent += []()
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		OnHudRender();
 	};
 

--- a/src/features/spotlights.h
+++ b/src/features/spotlights.h
@@ -29,7 +29,7 @@ public:
 	static void ProcessPointLights(CVehicle *pVeh);
 
 public:
-    SpotLights() : CVehFeature<SpotlightData>("SpotLights", "FEATURES", eFeatureMatrix::StandardLights) {}
+    SpotLights() : CVehFeature<SpotlightData>("SpotLights", "LIGHTS", eFeatureMatrix::SpotLights) {}
 	static bool IsEnabled(CVehicle *pVeh);
 	void ReloadConfig() override;
 	void Reload(CVehicle *pVeh) override;

--- a/src/features/wheel.cpp
+++ b/src/features/wheel.cpp
@@ -59,6 +59,7 @@ void ExtraWheel::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExtraWheels)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/wheelhub.cpp
+++ b/src/features/wheelhub.cpp
@@ -26,6 +26,7 @@ void WheelHub::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RotatingWheelHubs)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) {
             return;
         }

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -73,8 +73,7 @@ void ModelExtras::Init()
         {
             if (plugin::Command<TEST_CHEAT>("MERELOAD"))
             {
-                CVehicle *pVeh = FindPlayerVehicle(-1, false);
-                Reload(pVeh);
+                Reload();
             }
         };
     };
@@ -131,26 +130,32 @@ void ModelExtras::Init()
     RegisterFeature<SpotLights>();
     for (const auto &pFeature : m_Features)
     {
-        if (pFeature && pFeature->IsActive())
+        if (pFeature)
         {
             pFeature->Init();
         }
     }
 }
 
-void ModelExtras::Reload(CVehicle *pVeh)
+void ModelExtras::Reload()
 {
-    gConfig = CIniReader();
+    gConfig.data.clear();
     gConfig.SetIniPath();
     gVerboseLogging = gConfig.ReadBoolean("CONFIG", "VerboseLogging", false);
     AudioMgr::ReloadConfig();
     for (const auto &pFeature : m_Features) {
         if (pFeature) {
             pFeature->ReloadConfig();
-            pFeature->Reload(pVeh);
         }
     }
-    ModelInfoMgr::Reload(pVeh);
+    for (CVehicle *pVeh : CPools::ms_pVehiclePool) {
+        for (const auto &pFeature : m_Features) {
+            if (pFeature) {
+                pFeature->Reload(pVeh);
+            }
+        }
+        ModelInfoMgr::Reload(pVeh);
+    }
     static std::string msg = "~g~ModelExtras:~w~ Config reloaded";
     CMessages::AddMessageWithString(const_cast<char*>(msg.c_str()), 3000, false, nullptr, true);
     LOG(INFO) << "ModelExtras: Configuration reloaded successfully.";

--- a/src/loader.h
+++ b/src/loader.h
@@ -20,5 +20,5 @@ public:
     }
 
     static void Init();
-    static void Reload(CVehicle *pVeh);
+    static void Reload();
 };


### PR DESCRIPTION
### Summary

This PR enables full dynamic runtime toggling and live-reload (`MERELOAD`) support across all 27 features in ModelExtras.

---

### Key Architectural Improvements

1. **Clean Runtime Feature Enablement Checks (`CBaseFeature::IsEnabled`):**
   - Added a centralized `CBaseFeature::IsEnabled(eFeatureMatrix featureId)` bitset query.
   - All render and per-frame event callbacks across features (Backfire, Spoilers, Gauges, Doors, Roof, RollbackBed, LEDs, Clock, DirtFx, Wheels, Plates, Carcols, PedCols, Sirens, SoundEffects, Spotlights) now guard execution with an `IsEnabled` check at the top of their loops.

2. **Immediate Toggle On/Off via `MERELOAD` Without Restart:**
   - Setting any feature key to `0` in `ModelExtras.ini` immediately stops the feature's processing on the next frame upon `MERELOAD`.
   - Setting any feature key to `1` in `ModelExtras.ini` immediately resumes feature execution dynamically.

3. **Lifecycle Synchronization (`ReloadConfig`):**
   - Implemented uniform `ReloadConfig()` overrides for all features, ensuring feature-specific data tables (e.g. valid vehicle models lists) and internal enable flags are synchronized when the configuration reloads.
