### PR TITLE
fix(core): enable dynamic live-reload and runtime toggle support across all features

### DIFF
--- a/resource/dist/ModelExtras.ini
+++ b/resource/dist/ModelExtras.ini
@@ -5,6 +5,7 @@
 ## For vehicle model adaptation and documentation: https://github.com/user-grinch/ModelExtras/wiki                        ##
 ## For best viewing, use Notepad++ (syntax highlighting): https://notepad-plus-plus.org/downloads/                        ##
 ## Press CTRL+F in your text editor to quickly search for any setting.                                                    ##
+## Type 'MERELOAD' in-game to reload configuration and data files.                                                        ##
 ############################################################################################################################
 
 [FEATURES]
@@ -19,7 +20,7 @@ AnimatedSpoiler                      = 1            # Animated spoilers that mov
 AnimatedTurboMeter                   = 1            # Dashboard turbo meters for vehicles
 BackfireEffect                       = 1            # Sparks and flames come out of exhaust when accelerating
 BackfireEffect_OnlySelectedModels    = 1            # Backfire effect for selected vehicles only (check [TABLE])
-Carcols                              = 1            # Custom carcols loader
+Carcols                              = 1            # Custom carcols loader (automatically disabled in SA-MP)
 ConvertibleRoof                      = 1            # Animating vehicle rooftops
 DashboardLED                         = 1            # Dashboard LED lights for vehicles (engine, indicators, reverse, etc.)
 DigitalClock                         = 1            # Digital clock for the dashboard showing current time
@@ -34,41 +35,47 @@ TextureRemaper                       = 1            # Remaps textures for vehicl
 
 [LIGHTS]
 StandardLights                       = 1            # Lights for vehicles (headlights, taillights, indicators, etc.)
-StandardLightsv2                     = 1            # Use the new refactored StandardLights (WIP, features may be unavailable)
-StandardLights_GlobalIndicatorLights = 1            # Renders indicator (turn) lights for non-adapted vehicles
-AutoIndicatorsOnSteer                = 0            # Automatically activates turn indicators while steering (A/D or arrow keys)
-HeadLightBeams                       = 1            # Realistic projected volumetric beam lighting effect from vehicle headlights
+StandardLightsv2                     = 1            # Use the new refactored StandardLights
 LightCoronas                         = 1            # Coronas for lights (standard, siren, spotlights, etc.)
 LightShadows                         = 1            # Shadows for lights (standard, siren, spotlights, etc.)
 PointLights                          = 1            # Dynamic point lights on ground and surroundings for vehicle lights
+HeadLightBeams                       = 1            # Light beam effect from vehicle headlights
 SirenLights                          = 1            # Sirens for emergency vehicles
-SirenPointLights                     = 1            # Dynamic point lights for emergency vehicle sirens
+SirenPointLights                     = 0            # Dynamic point lights for emergency vehicle sirens
 SpotLights                           = 1            # Spotlights for emergency vehicles
+AutoIndicatorsOnSteer                = 0            # Automatically activates turn indicators while steering
+StandardLights_GlobalIndicatorLights = 1            # Renders indicator (turn) lights for non-adapted vehicles
 FoglightTiedToHeadlight              = 1            # Fog lights will only turn on when headlights are active
 LightCoronaSize                      = 0.3          # Base size for standard light coronas
 LightCoronaIntensity                 = 80           # Opacity and brightness of standard light coronas (0 - 255)
+CoronaDistanceMul                    = 0.1          # Scales coronas at distance during night time (0.0 to disable)
 LightShadowIntensity                 = 80           # Opacity of projected ground shadows/light pools (0 - 255)
 LightShadowDistance                  = 120.0        # Maximum draw distance for vehicle ground light shadows
-TailLightCoronaSize                  = 0.8          # Specific size for taillight coronas
-TailLightCoronaIntensity             = 60           # Specific brightness for taillight coronas (0 - 255)
-CoronaDistanceMul                    = 0.0          # Scales coronas at distance during night time (0.0 to disable)
-HighBeamPointLightMul                = 2.0          # Multiplier for high beam light reach (1.0 matches low beam, up to 4.0)
-LightHeightLimit                     = 0.5          # ImVehFt light height limit (0.0 to disable)
+HighBeamPointLightMul                = 2.0          # Multiplier for high beam point light reach (1.0 matches low beam, up to 4.0)
+LightHeightLimit                     = 0.5          # Light height limit (0.0 to disable)
 MaterialAmbientMul                   = 1.0          # Multiplier for illuminated light material ambient brightness
+HeadLightCoronaSize                  = 0.4          # Corona size for headlights
+HeadLightCoronaIntensity             = 80           # Corona brightness for headlights (0 - 255)
+HeadLightShadowSize                  = 1.0          # Shadow size multiplier for headlights
+HeadLightShadowIntensity             = 80           # Shadow opacity for headlights (0 - 255)
+TailLightCoronaSize                  = 0.4          # Corona size for taillights
+TailLightCoronaIntensity             = 60           # Corona brightness for taillights (0 - 255)
+TailLightShadowSize                  = 1.0          # Shadow size multiplier for taillights
+TailLightShadowIntensity             = 80           # Shadow opacity for taillights (0 - 255)
 
 [SOUND]
 SoundEffects                         = 1            # Master toggle for all ModelExtras sound effects
+SoundMult                            = 0.6          # Multiplier for ModelExtras audio effects (0.0 to 1.0)
+SoundEffects_GlobalAirbreakSound     = 1            # Plays engine air brake sound for big vehicles (check [TABLE])
 SoundEffects_GlobalEngineSound       = 1            # Plays engine on/off sound
 SoundEffects_GlobalIndicatorSound    = 1            # Plays indicator on/off sound
-SoundEffects_GlobalAirbreakSound     = 1            # Plays engine air brake sound for big vehicles (check [TABLE])
 SoundEffects_GlobalReverseSound      = 1            # Plays reverse sound for big vehicles (check [TABLE])
 SoundEffects_NonPlayerVehicles       = 1            # Plays sound effects for traffic vehicles too
-SoundMult                            = 0.6          # Multiplier for ModelExtras audio effects (0.0 to 1.0)
 
 [CONFIG]
 EnableLiveReload                     = 1            # Enables the 'MERELOAD' cheat to live-reload vehicle configs and INI settings without restarting
-EnableLogging                        = 1            # Writes diagnostic log messages to 'ModelExtras.log'
 ModelVersionCheck                    = 1            # Version check for ModelExtras models (recommended to keep enabled)
+EnableLogging                        = 1            # Writes diagnostic log messages to 'ModelExtras.log'
 VerboseLogging                       = 0            # Log extra info in log file, might cause performance issues (for developers)
 
 [KEYS]

--- a/src/features/backfire.cpp
+++ b/src/features/backfire.cpp
@@ -98,13 +98,22 @@ void BackFireEffect::BackFireMulti(CVehicle *pVeh)
 std::vector<int> ValidModels = {};
 bool onlySelected = false;
 
+void BackFireEffect::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    std::string line = gConfig.ReadString("TABLE", "BackFireEffect_VehicleModels", "");
+    onlySelected = gConfig.ReadBoolean("FEATURES", "BackfireEffect_OnlySelectedModels", true);
+    ValidModels.clear();
+    Util::GetModelsFromIni(line, ValidModels);
+}
+
 void BackFireEffect::Init()
 {
-    Events::initGameEvent += []()
+    ReloadConfig();
+
+    Events::initGameEvent += [this]()
     {
-        std::string line = gConfig.ReadString("TABLE", "BackFireEffect_VehicleModels", "");
-        onlySelected = gConfig.ReadBoolean("FEATURES", "BackfireEffect_OnlySelectedModels", true);
-        Util::GetModelsFromIni(line, ValidModels);
+        ReloadConfig();
     };
 
     Events::vehicleRenderEvent.before += [](CVehicle *vehicle)
@@ -116,6 +125,11 @@ void BackFireEffect::Init()
 // Inspired by Junior's https://www.mixmods.com.br/2016/06/backfire-als-v2-5-mod-estalar-escapamento/
 void BackFireEffect::Process(CVehicle *pVeh)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::BackfireEffect))
+    {
+        return;
+    }
+
     if (!pVeh->GetIsOnScreen() || pVeh->bEngineBroken || !pVeh->bEngineOn || pVeh->bIsBig || pVeh->bIsVan || pVeh->bIsBus || pVeh->bIsRCVehicle)
     {
         return;

--- a/src/features/backfire.h
+++ b/src/features/backfire.h
@@ -16,6 +16,8 @@ class BackFireEffect : public CVehFeature<BackfireData>
 {
 protected:
   void Init() override;
+  void ReloadConfig() override;
+  void Reload(CVehicle *pVeh) override { ReloadConfig(); }
   static void BackFireFX(CVehicle *pVeh, float x, float y, float z, float dirX = 0.0f, float dirY = -25.0f, float dirZ = 0.0f);
   static void BackFireSingle(CVehicle *pVeh);
   static void BackFireMulti(CVehicle *pVeh);

--- a/src/features/carcols.cpp
+++ b/src/features/carcols.cpp
@@ -10,9 +10,15 @@
      (type.g == VEHCOL.g) &&        \
      (type.b == VEHCOL.b))
 
+void Carcols::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void Carcols::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
 }
 
 bool Carcols::GetColor(CVehicle *pVeh, RpMaterial *pMat, CRGBA &col)

--- a/src/features/carcols.h
+++ b/src/features/carcols.h
@@ -30,6 +30,8 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
     Carcols() : CVehFeature<CarcolsData>("Carcols", "FEATURES", eFeatureMatrix::IVFCarcols) {}

--- a/src/features/chain.cpp
+++ b/src/features/chain.cpp
@@ -17,6 +17,9 @@ void ChainFeature::Init() {
   });
 
   ModelInfoMgr::RegisterRender([](CVehicle *pVeh) {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedChain)) {
+      return;
+    }
     if (!pVeh || !pVeh->GetIsOnScreen()) {
       return;
     }

--- a/src/features/clock.cpp
+++ b/src/features/clock.cpp
@@ -73,6 +73,7 @@ void DigitalClockFeature::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::Clock)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/core/base.cpp
+++ b/src/features/core/base.cpp
@@ -9,11 +9,11 @@ extern CIniReader gConfig;
 CBaseFeature::CBaseFeature(std::string name, std::string configSection, eFeatureMatrix featureId)
     : m_name(std::move(name)), m_configSection(std::move(configSection)), m_featureId(featureId) 
 {
-    if (IsActive()) {
-        m_bActive = true;
-        if (m_featureId <= eFeatureMatrix::FeatureCount) {
-            ModelExtras::m_bEnabledFeatures.set(static_cast<int>(m_featureId));
-        }
+    m_bActive = IsActive();
+    if (m_featureId <= eFeatureMatrix::FeatureCount) {
+        ModelExtras::m_bEnabledFeatures.set(static_cast<int>(m_featureId), m_bActive);
+    }
+    if (m_bActive) {
         LOG(INFO) << std::format("Feature '{}' enabled.", m_name);
     }
 }
@@ -23,6 +23,13 @@ bool CBaseFeature::IsActive() const {
     if (gConfig.ReadBoolean("LIGHTS", m_name, false)) return true;
     if (gConfig.ReadBoolean("SOUND", m_name, false)) return true;
     if (gConfig.ReadBoolean("FEATURES", m_name, false)) return true;
+    return false;
+}
+
+bool CBaseFeature::IsEnabled(eFeatureMatrix featureId) {
+    if (static_cast<size_t>(featureId) < ModelExtras::m_bEnabledFeatures.size()) {
+        return ModelExtras::m_bEnabledFeatures.test(static_cast<size_t>(featureId));
+    }
     return false;
 }
 

--- a/src/features/core/base.h
+++ b/src/features/core/base.h
@@ -25,6 +25,8 @@ public:
   virtual ~CBaseFeature() = default;
 
   [[nodiscard]] bool IsActive() const;
+  [[nodiscard]] bool IsActiveCached() const { return m_bActive; }
+  static bool IsEnabled(eFeatureMatrix featureId);
 
   virtual void Init() = 0;
   virtual void Shutdown() {}

--- a/src/features/dirtfx.cpp
+++ b/src/features/dirtfx.cpp
@@ -11,9 +11,15 @@ using namespace plugin;
 static CdeclEvent<AddressList<0x53CA75, H_CALL, 0x53CA61, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> CCarFXRenderer__ShutdownEvent;
 static CdeclEvent<AddressList<0x5B8FFD, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> CCarFXRenderer__InitialiseDirtTextureEvent;
 
+void DirtFx::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
+}
+
 void DirtFx::Init()
 {
-	m_bEnabled = true;
+	ReloadConfig();
 	
 	if (injector::GetBranchDestination(0x6D0E7E).as_int() != 0x5D5DB0) LOG(ERROR) << "Address conflict on 0x6D0E7E";
 	patch::Nop(0x6D0E7E, 5);

--- a/src/features/dirtfx.h
+++ b/src/features/dirtfx.h
@@ -31,9 +31,10 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-	public:
     DirtFx() : CBaseFeature("DirtFX", "FEATURES", eFeatureMatrix::DirtFX) {}
 	static void ProcessTextures(CVehicle *pVeh, RpMaterial *pMat);
 };

--- a/src/features/exhaust.cpp
+++ b/src/features/exhaust.cpp
@@ -25,6 +25,10 @@ NitroFn_t ogNitro1 = nullptr, ogNitro2 = nullptr, ogNitro3 = nullptr;
 void __fastcall ExhaustFx::hkAddExhaustParticles1(CVehicle * pVeh)
 {
     if (!pVeh) return;
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx)) {
+        if (ogFunc1) ogFunc1(pVeh);
+        return;
+    }
     auto &data = m_VehData.Get(pVeh);
     if (!data.isUsed && ogFunc1) {
         ogFunc1(pVeh);
@@ -34,6 +38,10 @@ void __fastcall ExhaustFx::hkAddExhaustParticles1(CVehicle * pVeh)
 void __fastcall ExhaustFx::hkAddExhaustParticles2(CVehicle *pVeh)
 {
     if (!pVeh) return;
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx)) {
+        if (ogFunc2) ogFunc2(pVeh);
+        return;
+    }
     auto &data = m_VehData.Get(pVeh);
     if (!data.isUsed && ogFunc2) {
         ogFunc2(pVeh);
@@ -266,6 +274,10 @@ ExhaustData ExhaustFx::LoadData(CVehicle *pVeh, RwFrame *pFrame)
 
 void ExhaustFx::RenderSmokeFx(CVehicle *pVeh, const ExhaustData &info)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx))
+    {
+        return;
+    }
     if (!pVeh || !pVeh->GetIsOnScreen() || !pVeh->bEngineOn || pVeh->bEngineBroken)
     {
         return;
@@ -377,6 +389,10 @@ void ExhaustFx::RenderSmokeFx(CVehicle *pVeh, const ExhaustData &info)
 
 void ExhaustFx::RenderNitroFx(CVehicle *pVeh, float power)
 {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExhaustFx))
+    {
+        return;
+    }
     const auto &mi = CModelInfo::GetModelInfo(pVeh->m_nModelIndex);
 
     auto &data = m_VehData.Get(pVeh);

--- a/src/features/gauge.cpp
+++ b/src/features/gauge.cpp
@@ -28,6 +28,7 @@ void GearIndicator::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedGearMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehGearData &data = m_VehData.Get(pVeh);
@@ -67,6 +68,7 @@ void MileageIndicator::Init()
     });
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh) {
+    if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedOdoMeter)) return;
     if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
     VehMileageData &data = m_VehData.Get(pVeh);
@@ -139,6 +141,7 @@ void RPMGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedRpmMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehRPMData &data = m_VehData.Get(pVeh);
@@ -207,6 +210,7 @@ void SpeedGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedSpeedMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehSpeedData &data = m_VehData.Get(pVeh);
@@ -255,6 +259,7 @@ void TurboGauge::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedTurboMeter)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         VehTurboData &data = m_VehData.Get(pVeh);

--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -17,9 +17,15 @@
 #include "roof.h"
 #include "lights.h"
 
+void DashboardLEDs::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	bEnabled = m_bActive;
+}
+
 void DashboardLEDs::Init()
 {
-	bEnabled = true;
+	ReloadConfig();
 
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat){
 		if (!bEnabled) {

--- a/src/features/leds.h
+++ b/src/features/leds.h
@@ -20,8 +20,9 @@ private:
 	
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-	public:
     DashboardLEDs() : CVehFeature<VehLEDData>("DashboardLED", "FEATURES", eFeatureMatrix::DashboardLED) {}
 };

--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -26,8 +26,17 @@ static bool gbLightCoronasFeature = false;
 float gfGlobalCoronaSize = 0.3f;
 int gGlobalCoronaIntensity = 80;
 int gGlobalShadowIntensity = 80;
-float gfTailLightCoronaSize = 0.8f;
+
+float gfHeadLightCoronaSize = 0.4f;
+int gHeadLightCoronaIntensity = 80;
+int gHeadLightShadowIntensity = 80;
+float gfHeadLightShadowSize = 1.0f;
+
+float gfTailLightCoronaSize = 0.4f;
 int gTailLightCoronaIntensity = 60;
+int gTailLightShadowIntensity = 80;
+float gfTailLightShadowSize = 1.0f;
+
 float headlightSz = 5.0f;
 
 int GetStrobeIndex(CVehicle *pVeh, RpMaterial *pMat)
@@ -70,7 +79,7 @@ inline float GetZAngleForPoint(CVector2D const &point)
 }
 
 bool gbLightPointLights = true;
-bool gbSirenPointLights = true;
+bool gbSirenPointLights = false;
 
 static uint32_t g_nFogLightKey = VK_J;
 static uint32_t g_nLongLightKey = VK_G;
@@ -86,13 +95,21 @@ void Lights::InitConfig()
 	gbGlobalIndicatorLights = gConfig.ReadBoolean("LIGHTS", "StandardLights_GlobalIndicatorLights", gConfig.ReadBoolean("FEATURES", "StandardLights_GlobalIndicatorLights", false));
 	gbLightCoronasFeature = gConfig.ReadBoolean("LIGHTS", "LightCoronas", gConfig.ReadBoolean("FEATURES", "LightCoronas", false));
 	gbLightPointLights = gConfig.ReadBoolean("LIGHTS", "PointLights", gConfig.ReadBoolean("LIGHTS", "LightPointLights", gConfig.ReadBoolean("FEATURES", "PointLights", true)));
-	gbSirenPointLights = gConfig.ReadBoolean("LIGHTS", "SirenPointLights", gConfig.ReadBoolean("FEATURES", "SirenPointLights", true));
+	gbSirenPointLights = gConfig.ReadBoolean("LIGHTS", "SirenPointLights", gConfig.ReadBoolean("FEATURES", "SirenPointLights", false));
 
 	gfGlobalCoronaSize = gConfig.ReadFloat("LIGHTS", "LightCoronaSize", gConfig.ReadFloat("VISUAL", "LightCoronaSize", 0.3f));
 	gGlobalShadowIntensity = gConfig.ReadInteger("LIGHTS", "LightShadowIntensity", gConfig.ReadInteger("VISUAL", "LightShadowIntensity", 80));
 	gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 80));
-	gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.8f));
+
+	gfHeadLightCoronaSize = gConfig.ReadFloat("LIGHTS", "HeadLightCoronaSize", gfGlobalCoronaSize);
+	gHeadLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "HeadLightCoronaIntensity", gGlobalCoronaIntensity);
+	gHeadLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "HeadLightShadowIntensity", gGlobalShadowIntensity);
+	gfHeadLightShadowSize = gConfig.ReadFloat("LIGHTS", "HeadLightShadowSize", 1.0f);
+
+	gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.4f));
 	gTailLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "TailLightCoronaIntensity", gConfig.ReadInteger("VISUAL", "TailLightCoronaIntensity", 60));
+	gTailLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "TailLightShadowIntensity", gGlobalShadowIntensity);
+	gfTailLightShadowSize = gConfig.ReadFloat("LIGHTS", "TailLightShadowSize", 1.0f);
 
 	g_nFogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", VK_J);
 	g_nLongLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", VK_G);
@@ -110,7 +127,7 @@ void Lights::Init()
 		return;
 	}
 
-	m_bEnabled = true;
+	ReloadConfig();
 	patch::Nop(0x6E2722, 19);	  // CVehicle::DoHeadLightReflection
 	patch::SetUChar(0x6E1A22, 0); // CVehicle::DoTailLightEffect
 
@@ -371,7 +388,8 @@ void Lights::Init()
 			c.lightType = eMaterialType::TailLightRight;
 			c.corona.size = gfTailLightCoronaSize;
 			c.corona.color = {250, 0, 0, static_cast<unsigned char>(gTailLightCoronaIntensity)};
-			c.shadow.color = {250, 0, 0, static_cast<unsigned char>(gGlobalShadowIntensity)};
+			c.shadow.color = {250, 0, 0, static_cast<unsigned char>(gTailLightShadowIntensity)};
+			c.shadow.size = gfTailLightShadowSize;
 			c.corona.lightingType = eLightingMode::Directional; 				
 			c.shadow.render = name != "taillights2";
 			dummies[c.lightType].push_back(new VehicleDummy(c));
@@ -385,7 +403,10 @@ void Lights::Init()
 		else if (name == "headlights" || name == "headlights2") {
 			c.dummyPos = eDummyPos::Front;
 			c.lightType = eMaterialType::HeadLightLeft;
-			c.corona.color = c.shadow.color = {250, 250, 250, static_cast<unsigned char>(gGlobalCoronaIntensity)};
+			c.corona.size = gfHeadLightCoronaSize;
+			c.corona.color = {250, 250, 250, static_cast<unsigned char>(gHeadLightCoronaIntensity)};
+			c.shadow.color = {250, 250, 250, static_cast<unsigned char>(gHeadLightShadowIntensity)};
+			c.shadow.size = gfHeadLightShadowSize;
 			c.corona.lightingType = eLightingMode::Directional;
 			c.shadow.render = name != "headlights2";
 			c.mirroredX = true;
@@ -506,7 +527,7 @@ void Lights::Init()
 				continue;
 			}
 
-			if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 150.0f || pVeh->GetIsOnScreen())
+			if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 300.0f || pVeh->GetIsOnScreen())
 			{
 				bool isLeftFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_LEFT);
 				bool isRightFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_RIGHT);
@@ -603,7 +624,7 @@ void Lights::Init()
 		}
 
 		std::string shdwName = (isBike ? "taillight_bike" : "taillight");
-		float shdwSz = 2.0f;
+		float shdwSz = 1.6f;
 
 		if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK
 			|| pControlVeh->m_nVehicleSubClass == VEHICLE_QUAD || pControlVeh->m_nVehicleSubClass == VEHICLE_BIKE
@@ -994,9 +1015,16 @@ void Lights::EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMu
 
 // NOT
 
+void Lights::ReloadConfig()
+{
+	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
+	InitConfig();
+}
+
 void Lights::Reload(CVehicle* pVeh)
 {
-	InitConfig();
+	ReloadConfig();
 	if (pVeh) {
 		auto it = m_Dummies.find(pVeh);
 		if (it != m_Dummies.end()) {

--- a/src/features/lights.h
+++ b/src/features/lights.h
@@ -60,6 +60,7 @@ public:
 	static VehLightDatav1 GetVehicleData(CVehicle *pVeh);
 
 	friend int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat);
+	void ReloadConfig() override;
 	void Reload(CVehicle* pVeh) override;
 
 	static bool GetLightState(CVehicle *pVeh, eMaterialType lightId);

--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -25,7 +25,10 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.dummyPos = eDummyPos::Front;
         c.lightType = eMaterialType::HeadLightLeft;
-        c.corona.color = c.shadow.color = {250, 250, 250, static_cast<unsigned char>(LightsConfig::Get().gGlobalCoronaIntensity)};
+        c.corona.size = LightsConfig::Get().gfHeadLightCoronaSize;
+        c.corona.color = {250, 250, 250, static_cast<unsigned char>(LightsConfig::Get().gHeadLightCoronaIntensity)};
+        c.shadow.color = {250, 250, 250, static_cast<unsigned char>(LightsConfig::Get().gHeadLightShadowIntensity)};
+        c.shadow.size = LightsConfig::Get().gfHeadLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
         c.shadow.render = name != "headlights2";
         
@@ -60,7 +63,7 @@ void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
             return;
         }
 
-        if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 150.0f || pVeh->GetIsOnScreen()) {
+        if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 300.0f || pVeh->GetIsOnScreen()) {
             bool isLeftFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_LEFT);
             bool isRightFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_RIGHT);
             bool isNightOrOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);

--- a/src/features/lights/components/tail_light.cpp
+++ b/src/features/lights/components/tail_light.cpp
@@ -24,7 +24,8 @@ bool TailLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
         c.lightType = eMaterialType::TailLightRight;
         c.corona.size = LightsConfig::Get().gfTailLightCoronaSize;
         c.corona.color = {250, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightCoronaIntensity)};
-        c.shadow.color = {250, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gGlobalShadowIntensity)};
+        c.shadow.color = {250, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightShadowIntensity)};
+        c.shadow.size = LightsConfig::Get().gfTailLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
         c.shadow.render = name != "taillights2";
         c.mirroredX = false;
@@ -43,7 +44,7 @@ bool TailLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
     std::string shdwName = (isBike ? "taillight_bike" : "taillight");
-    float shdwSz = 2.0f;
+    float shdwSz = 1.6f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK
         || pControlVeh->m_nVehicleSubClass == VEHICLE_QUAD || pControlVeh->m_nVehicleSubClass == VEHICLE_BIKE

--- a/src/features/lights/data.h
+++ b/src/features/lights/data.h
@@ -17,13 +17,22 @@ struct LightsConfig {
     bool gbGlobalIndicatorLights = false;
     bool gbLightCoronasFeature = false;
     bool gbLightPointLights = true;
-    bool gbSirenPointLights = true;
+    bool gbSirenPointLights = false;
 
     float gfGlobalCoronaSize = 0.3f;
     int gGlobalCoronaIntensity = 80;
     int gGlobalShadowIntensity = 80;
-    float gfTailLightCoronaSize = 0.8f;
+
+    float gfHeadLightCoronaSize = 0.4f;
+    int gHeadLightCoronaIntensity = 80;
+    int gHeadLightShadowIntensity = 80;
+    float gfHeadLightShadowSize = 1.0f;
+
+    float gfTailLightCoronaSize = 0.4f;
     int gTailLightCoronaIntensity = 60;
+    int gTailLightShadowIntensity = 80;
+    float gfTailLightShadowSize = 1.0f;
+
     float headlightSz = 5.0f;
 
     uint32_t nFogLightKey = 'J';
@@ -40,13 +49,21 @@ struct LightsConfig {
         gbGlobalIndicatorLights = gConfig.ReadBoolean("LIGHTS", "StandardLights_GlobalIndicatorLights", gConfig.ReadBoolean("FEATURES", "StandardLights_GlobalIndicatorLights", false));
         gbLightCoronasFeature = gConfig.ReadBoolean("LIGHTS", "LightCoronas", gConfig.ReadBoolean("FEATURES", "LightCoronas", false));
         gbLightPointLights = gConfig.ReadBoolean("LIGHTS", "PointLights", gConfig.ReadBoolean("LIGHTS", "LightPointLights", gConfig.ReadBoolean("FEATURES", "PointLights", true)));
-        gbSirenPointLights = gConfig.ReadBoolean("LIGHTS", "SirenPointLights", gConfig.ReadBoolean("FEATURES", "SirenPointLights", true));
+        gbSirenPointLights = gConfig.ReadBoolean("LIGHTS", "SirenPointLights", gConfig.ReadBoolean("FEATURES", "SirenPointLights", false));
 
         gfGlobalCoronaSize = gConfig.ReadFloat("LIGHTS", "LightCoronaSize", gConfig.ReadFloat("VISUAL", "LightCoronaSize", 0.3f));
         gGlobalShadowIntensity = gConfig.ReadInteger("LIGHTS", "LightShadowIntensity", gConfig.ReadInteger("VISUAL", "LightShadowIntensity", 80));
         gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 80));
-        gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.8f));
+
+        gfHeadLightCoronaSize = gConfig.ReadFloat("LIGHTS", "HeadLightCoronaSize", gfGlobalCoronaSize);
+        gHeadLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "HeadLightCoronaIntensity", gGlobalCoronaIntensity);
+        gHeadLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "HeadLightShadowIntensity", gGlobalShadowIntensity);
+        gfHeadLightShadowSize = gConfig.ReadFloat("LIGHTS", "HeadLightShadowSize", 1.0f);
+
+        gfTailLightCoronaSize = gConfig.ReadFloat("LIGHTS", "TailLightCoronaSize", gConfig.ReadFloat("VISUAL", "TailLightCoronaSize", 0.4f));
         gTailLightCoronaIntensity = gConfig.ReadInteger("LIGHTS", "TailLightCoronaIntensity", gConfig.ReadInteger("VISUAL", "TailLightCoronaIntensity", 60));
+        gTailLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "TailLightShadowIntensity", gGlobalShadowIntensity);
+        gfTailLightShadowSize = gConfig.ReadFloat("LIGHTS", "TailLightShadowSize", 1.0f);
 
         nFogLightKey = gConfig.ReadInteger("KEYS", "FogLightKey", 'J');
         nLongLightKey = gConfig.ReadInteger("KEYS", "LongLightKey", 'G');

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -9,6 +9,7 @@ void LightsFeature::Init() {
 		return;
 	}
 
+    ReloadConfig();
     LightManager::Init();
 
     patch::Nop(0x6E2722, 19);	  // CVehicle::DoHeadLightReflection
@@ -32,6 +33,7 @@ void LightsFeature::Init() {
 	};
 
     ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat) {
+        if (!m_bEnabled) return eMaterialType::UnknownMaterial;
         return LightManager::GetMatType(pMat); 
     });
 
@@ -41,11 +43,13 @@ void LightsFeature::Init() {
 
 	MEEvents::vehPreRenderEvent.before += [](CVehicle *pVeh)
 	{
+		if (!m_bEnabled) return;
 		LightManager::ProcessPointLights(pVeh);
 	};
 
 	Events::processScriptsEvent += []()
 	{
+		if (!m_bEnabled) return;
 		BlinkerState::Get().Update();
 
 		for (CVehicle *pVeh : CPools::ms_pVehiclePool)
@@ -61,6 +65,7 @@ void LightsFeature::Init() {
 	};
 
 	ModelInfoMgr::RegisterRender([](CVehicle *pControlVeh) {
+		if (!m_bEnabled) return;
 		int model = pControlVeh->m_nModelIndex;
 
 		if (CModelInfo::IsTrailerModel(model)) {
@@ -78,6 +83,7 @@ void LightsFeature::Init() {
 
 void LightsFeature::ReloadConfig() {
 	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
 	LightsConfig::Get().InitConfig();
 }
 

--- a/src/features/lights/lights.h
+++ b/src/features/lights/lights.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "core/base.h"
 
-class LightsFeature : public CBaseFeature{
+class LightsFeature : public CBaseFeature {
 protected:
     void Init() override;
 
 public:
-    LightsFeature() : CBaseFeature("StandardLightsv2", "FEATURES", eFeatureMatrix::StandardLights) {}
+    static inline bool m_bEnabled = false;
+    LightsFeature() : CBaseFeature("StandardLightsv2", "LIGHTS", eFeatureMatrix::REMOVED_NULL) {}
     void ReloadConfig() override;
     void Reload(CVehicle* pVeh) override;
 };

--- a/src/features/pedcols.cpp
+++ b/src/features/pedcols.cpp
@@ -96,6 +96,7 @@ void PedColors::Init() {
 	};
 
 	Events::pedRenderEvent.before += [](CPed *pPed) {
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::PedCols)) return;
 		auto &data = PedColors::m_PedData.Get(pPed);
 		if (data.m_bUsingPedCols) {
 			PedColors::m_pCurrentPed = pPed;

--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -18,9 +18,15 @@ using namespace plugin;
 
 static CVehicle *pCurrentVeh = nullptr;
 
+void LicensePlate::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void LicensePlate::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
     // RpMaterial *__cdecl CCustomCarPlateMgr::SetupMaterialPlatebackTexture(RpMaterial *material, char plateType)
     patch::PutRetn(0x6FDE50);
     patch::ReplaceFunction(0x6FD500, (void *)CCustomCarPlateMgr_Initialise);

--- a/src/features/plate.h
+++ b/src/features/plate.h
@@ -60,9 +60,10 @@ private:
 
 protected:
     void Init() override;
+    void ReloadConfig() override;
+    void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
-  public:
     LicensePlate() : CVehFeature<PlateData>("HDLicensePlate", "FEATURES", eFeatureMatrix::HDLicensePlate) {}
   static void ProcessTextures(CVehicle *pVeh, RpMaterial *pMat);
 };

--- a/src/features/remap.cpp
+++ b/src/features/remap.cpp
@@ -7,9 +7,15 @@
 #include <rw/rpworld.h>
 #include <algorithm>
 
+void Remap::ReloadConfig()
+{
+    CBaseFeature::ReloadConfig();
+    m_bEnabled = m_bActive;
+}
+
 void Remap::Init()
 {
-    m_bEnabled = true;
+    ReloadConfig();
 }
 
 void Remap::LoadRemaps(CVehicle* vehicle)

--- a/src/features/remap.h
+++ b/src/features/remap.h
@@ -26,6 +26,8 @@ private:
 
 protected:
   void Init() override;
+  void ReloadConfig() override;
+  void Reload(CVehicle *pVeh) override { ReloadConfig(); }
 
 public:
   Remap() : CVehFeature<RemapVehData>("TextureRemaper", "FEATURES", eFeatureMatrix::TextureRemapper) {}

--- a/src/features/rollbackbed.cpp
+++ b/src/features/rollbackbed.cpp
@@ -152,6 +152,7 @@ void RollbackBed::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RollbackBed)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;
@@ -175,6 +176,7 @@ void RollbackBed::Init()
 
     Events::processScriptsEvent += []()
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RollbackBed)) return;
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
 

--- a/src/features/roof.cpp
+++ b/src/features/roof.cpp
@@ -91,6 +91,7 @@ void ConvertibleRoof::Init()
 
     Events::vehicleRenderEvent += [](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         bool isRainy = (CWeather::Rain > 0.05f) || (CWeather::WetRoads > 0.1f) || (CWeather::NewWeatherType == eWeatherType::WEATHER_RAINY_SF || CWeather::OldWeatherType == eWeatherType::WEATHER_RAINY_SF || CWeather::NewWeatherType == eWeatherType::WEATHER_RAINY_COUNTRYSIDE || CWeather::OldWeatherType == eWeatherType::WEATHER_RAINY_COUNTRYSIDE);
         if (!isRainy)
         {
@@ -106,6 +107,7 @@ void ConvertibleRoof::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) {
             return;
         }
@@ -165,6 +167,7 @@ void ConvertibleRoof::Init()
 
     Events::processScriptsEvent += []()
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ConvertibleRoof)) return;
         size_t now = CTimer::m_snTimeInMilliseconds;
         static size_t prev = 0;
 

--- a/src/features/rotatedoor.cpp
+++ b/src/features/rotatedoor.cpp
@@ -66,6 +66,7 @@ void RotateDoor::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle* pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedDoors)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         RotateDoorData& data = m_VehData.Get(pVeh);

--- a/src/features/sirens.cpp
+++ b/src/features/sirens.cpp
@@ -65,6 +65,7 @@ static uint32_t g_nSirenKey = VK_L;
 void Sirens::ReloadConfig()
 {
 	CBaseFeature::ReloadConfig();
+	m_bEnabled = m_bActive;
 	g_nSirenKey = gConfig.ReadInteger("KEYS", "SirenLightKey", VK_L);
 }
 
@@ -605,7 +606,7 @@ int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat)
 
 void Sirens::Init()
 {
-	m_bEnabled = true;
+	ReloadConfig();
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat)
 								   {
 		if (!m_bEnabled) {

--- a/src/features/slidedoor.cpp
+++ b/src/features/slidedoor.cpp
@@ -60,6 +60,7 @@ void SlideDoor::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedDoors)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) return;
 
         SlideDoorData& data = m_VehData.Get(pVeh);

--- a/src/features/soundeffects.cpp
+++ b/src/features/soundeffects.cpp
@@ -20,6 +20,7 @@ static bool bOnlyPlayerVehicle = true;
 
 void SoundEffects::ReloadConfig()
 {
+    CBaseFeature::ReloadConfig();
     std::string line = gConfig.ReadString("TABLE", "SoundEffects_BigVehicleModels", "");
     ValidForReverseSound.clear();
     Util::GetModelsFromIni(line, ValidForReverseSound);
@@ -38,12 +39,17 @@ void SoundEffects::Reload(CVehicle *pVeh)
 
 void SoundEffects::Init()
 {
-    Events::initGameEvent += []()
+    ReloadConfig();
+
+    Events::initGameEvent += [this]()
     {
         ReloadConfig();
     };
 
     Events::processScriptsEvent += []() {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::SoundEffects)) {
+            return;
+        }
         CPed *pPlayer = FindPlayerPed();
         if (!pPlayer) {
             return;

--- a/src/features/soundeffects.h
+++ b/src/features/soundeffects.h
@@ -22,7 +22,7 @@ class SoundEffects : public CVehFeature<SoundEffectsData>
 protected:
     void Init() override;
     void Reload(CVehicle *pVeh) override;
-    static void ReloadConfig();
+    void ReloadConfig() override;
 
 public:
     SoundEffects() : CVehFeature<SoundEffectsData>("SoundEffects", "SOUND", eFeatureMatrix::SoundEffects) {}

--- a/src/features/spoiler.cpp
+++ b/src/features/spoiler.cpp
@@ -57,6 +57,10 @@ void Spoiler::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                 {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::AnimatedSpoiler))
+        {
+            return;
+        }
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/spotlights.cpp
+++ b/src/features/spotlights.cpp
@@ -25,6 +25,7 @@ static inline CVector2D GetPerpRight(const CVector2D &vec)
 
 void SpotLights::Init()
 {
+	ReloadConfig();
 	ModelInfoMgr::RegisterDummy([](CVehicle *pVeh, RwFrame *pFrame, const std::string_view nodeName)
 	{
 		SpotlightData &data = m_VehData.Get(pVeh);
@@ -38,6 +39,7 @@ void SpotLights::Init()
 
 	Events::vehicleRenderEvent += [](CVehicle *pVeh)
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		if (!pVeh || !pVeh->GetIsOnScreen())
 		{
 			return;
@@ -47,11 +49,13 @@ void SpotLights::Init()
 
 	MEEvents::vehPreRenderEvent.before += [](CVehicle *pVeh)
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		ProcessPointLights(pVeh);
 	};
 
 	Events::processScriptsEvent += []()
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		for (CVehicle *pVeh : CPools::ms_pVehiclePool)
 		{
 			if (pVeh && pVeh->m_nVehicleSubClass == VEHICLE_BIKE)
@@ -63,6 +67,7 @@ void SpotLights::Init()
 
 	Events::drawingEvent += []()
 	{
+		if (!CBaseFeature::IsEnabled(eFeatureMatrix::SpotLights)) return;
 		OnHudRender();
 	};
 

--- a/src/features/spotlights.h
+++ b/src/features/spotlights.h
@@ -29,7 +29,7 @@ public:
 	static void ProcessPointLights(CVehicle *pVeh);
 
 public:
-    SpotLights() : CVehFeature<SpotlightData>("SpotLights", "FEATURES", eFeatureMatrix::StandardLights) {}
+    SpotLights() : CVehFeature<SpotlightData>("SpotLights", "LIGHTS", eFeatureMatrix::SpotLights) {}
 	static bool IsEnabled(CVehicle *pVeh);
 	void ReloadConfig() override;
 	void Reload(CVehicle *pVeh) override;

--- a/src/features/wheel.cpp
+++ b/src/features/wheel.cpp
@@ -59,6 +59,7 @@ void ExtraWheel::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
                                  {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::ExtraWheels)) return;
         if (!pVeh || !pVeh->GetIsOnScreen())
         {
             return;

--- a/src/features/wheelhub.cpp
+++ b/src/features/wheelhub.cpp
@@ -26,6 +26,7 @@ void WheelHub::Init()
 
     ModelInfoMgr::RegisterRender([](CVehicle *pVeh)
     {
+        if (!CBaseFeature::IsEnabled(eFeatureMatrix::RotatingWheelHubs)) return;
         if (!pVeh || !pVeh->GetIsOnScreen()) {
             return;
         }

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -73,8 +73,7 @@ void ModelExtras::Init()
         {
             if (plugin::Command<TEST_CHEAT>("MERELOAD"))
             {
-                CVehicle *pVeh = FindPlayerVehicle(-1, false);
-                Reload(pVeh);
+                Reload();
             }
         };
     };
@@ -131,26 +130,33 @@ void ModelExtras::Init()
     RegisterFeature<SpotLights>();
     for (const auto &pFeature : m_Features)
     {
-        if (pFeature && pFeature->IsActive())
+        if (pFeature)
         {
             pFeature->Init();
         }
     }
 }
 
-void ModelExtras::Reload(CVehicle *pVeh)
+void ModelExtras::Reload()
 {
-    gConfig = CIniReader();
+    gConfig.data.clear();
     gConfig.SetIniPath();
     gVerboseLogging = gConfig.ReadBoolean("CONFIG", "VerboseLogging", false);
     AudioMgr::ReloadConfig();
+    RenderUtil::ReloadConfig();
     for (const auto &pFeature : m_Features) {
         if (pFeature) {
             pFeature->ReloadConfig();
-            pFeature->Reload(pVeh);
         }
     }
-    ModelInfoMgr::Reload(pVeh);
+    for (CVehicle *pVeh : CPools::ms_pVehiclePool) {
+        for (const auto &pFeature : m_Features) {
+            if (pFeature) {
+                pFeature->Reload(pVeh);
+            }
+        }
+        ModelInfoMgr::Reload(pVeh);
+    }
     static std::string msg = "~g~ModelExtras:~w~ Config reloaded";
     CMessages::AddMessageWithString(const_cast<char*>(msg.c_str()), 3000, false, nullptr, true);
     LOG(INFO) << "ModelExtras: Configuration reloaded successfully.";

--- a/src/loader.h
+++ b/src/loader.h
@@ -20,5 +20,5 @@ public:
     }
 
     static void Init();
-    static void Reload(CVehicle *pVeh);
+    static void Reload();
 };

--- a/src/utils/render.cpp
+++ b/src/utils/render.cpp
@@ -66,11 +66,13 @@ bool IsDummyPointingUp(CMatrix mat)
 
 static bool gbLightCoronas = false;
 static bool gbLightShadows = false;
-static float gfCoronaDistanceMul = 0.0f;
+static float gfCoronaDistanceMul = 0.1f;
 static float gfCoronaNearClip = 0.45f;
 static float gfLightHeightLimit = 0.0f;
 static bool gbConfigInitialized = false;
 static float gfLightShadowDistance = 120.0f;
+static int gnHeadLightShadowIntensity = 80;
+static int gnTailLightShadowIntensity = 80;
 
 extern int gGlobalShadowIntensity;
 extern int gGlobalCoronaIntensity;
@@ -79,11 +81,13 @@ void RenderUtil::ReloadConfig()
 {
     gbLightCoronas = gConfig.ReadBoolean("LIGHTS", "LightCoronas", gConfig.ReadBoolean("FEATURES", "LightCoronas", true));
     gbLightShadows = gConfig.ReadBoolean("LIGHTS", "LightShadows", gConfig.ReadBoolean("FEATURES", "LightShadows", true));
-    gfCoronaDistanceMul = gConfig.ReadFloat("LIGHTS", "CoronaDistanceMul", gConfig.ReadFloat("TWEAKS", "CoronaDistanceMul", 0.0f));
+    gfCoronaDistanceMul = gConfig.ReadFloat("LIGHTS", "CoronaDistanceMul", gConfig.ReadFloat("TWEAKS", "CoronaDistanceMul", 0.1f));
     gfCoronaNearClip = gConfig.ReadFloat("LIGHTS", "CoronaNearClip", gConfig.ReadFloat("TWEAKS", "CoronaNearClip", 0.45f));
     gfLightHeightLimit = gConfig.ReadFloat("LIGHTS", "LightHeightLimit", gConfig.ReadFloat("TWEAKS", "LightHeightLimit", 0.0f));
     gGlobalShadowIntensity = gConfig.ReadInteger("LIGHTS", "LightShadowIntensity", gConfig.ReadInteger("VISUAL", "LightShadowIntensity", 80));
     gGlobalCoronaIntensity = gConfig.ReadInteger("LIGHTS", "LightCoronaIntensity", gConfig.ReadInteger("VISUAL", "LightCoronaIntensity", 80));
+    gnHeadLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "HeadLightShadowIntensity", gGlobalShadowIntensity);
+    gnTailLightShadowIntensity = gConfig.ReadInteger("LIGHTS", "TailLightShadowIntensity", gGlobalShadowIntensity);
     gfLightShadowDistance = gConfig.ReadFloat("LIGHTS", "LightShadowDistance", 120.0f);
     gbConfigInitialized = true;
 }
@@ -397,7 +401,26 @@ void RenderUtil::RegisterCoronaDirectional(const DummyConfig *pConfig, float ang
     RegisterCorona(pConfig->pVeh, reinterpret_cast<int32_t>(pConfig), pConfig->position, col, sz);
 }
 
-extern int gGlobalShadowIntensity;
+// Shadow opacity is resolved here so the per light type INI keys are respected. The dummy's
+// alpha is baked in when the dummy is created, so reading it back would go stale after a reload.
+static int GetShadowIntensity(eMaterialType lightType)
+{
+    int intensity = gGlobalShadowIntensity;
+    switch (lightType)
+    {
+    case eMaterialType::HeadLightLeft:
+    case eMaterialType::HeadLightRight:
+        intensity = gnHeadLightShadowIntensity;
+        break;
+    case eMaterialType::TailLightLeft:
+    case eMaterialType::TailLightRight:
+        intensity = gnTailLightShadowIntensity;
+        break;
+    default:
+        break;
+    }
+    return std::clamp(intensity, 0, 255);
+}
 
 void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std::string &shadwTexName, float shdwSz)
 {
@@ -488,7 +511,7 @@ void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std
         alphaMul = (SHDW_MAX_DIST - distToCam) / (SHDW_MAX_DIST - SHDW_FADE_DIST);
     }
 
-    float shadowIntensityFactor = static_cast<float>(gGlobalShadowIntensity) / 255.0f;
+    float shadowIntensityFactor = static_cast<float>(GetShadowIntensity(pConfig->lightType)) / 255.0f;
     unsigned char r = static_cast<unsigned char>(pConfig->shadow.color.r * shadowIntensityFactor);
     unsigned char g = static_cast<unsigned char>(pConfig->shadow.color.g * shadowIntensityFactor);
     unsigned char b = static_cast<unsigned char>(pConfig->shadow.color.b * shadowIntensityFactor);


### PR DESCRIPTION
### Summary

This PR enables full dynamic runtime toggling and live-reload (`MERELOAD`) support across all features in ModelExtras.

---

### Key Architectural Improvements

1. **Clean Runtime Feature Enablement Queries (`CBaseFeature::IsEnabled`):**
   - Added a centralized `CBaseFeature::IsEnabled(eFeatureMatrix featureId)` bitset query.
   - All render and per-frame event callbacks across features now guard execution with an `IsEnabled` check at the top of their loops.

2. **Immediate Toggle On/Off via `MERELOAD` Without Restart:**
   - Setting any feature key to `0` in `ModelExtras.ini` immediately stops the feature's processing on the next frame upon `MERELOAD`.
   - Setting any feature key to `1` in `ModelExtras.ini` immediately resumes feature execution dynamically.

3. **Lifecycle Synchronization (`ReloadConfig`):**
   - Implemented uniform `ReloadConfig()` overrides for features, ensuring feature-specific data tables (e.g. valid vehicle models lists, render shadow multipliers) and internal enable flags are synchronized when the configuration reloads.