### PR TITLE
fix(lights): require active headlights for high beam toggle and sound

### DIFF
--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -105,10 +105,12 @@ void DashboardLEDs::Init()
 			EnableLED(pControlVeh, eMaterialType::FogLightLed);
 		}
 		bool headlightsOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
-		if (data.m_bLongLightsOn) {
-			EnableLED(pControlVeh, eMaterialType::HighBeamLed);
-		} else if (headlightsOn) {
-			EnableLED(pControlVeh, eMaterialType::LowBeamLed);
+		if (headlightsOn) {
+			if (data.m_bLongLightsOn) {
+				EnableLED(pControlVeh, eMaterialType::HighBeamLed);
+			} else {
+				EnableLED(pControlVeh, eMaterialType::LowBeamLed);
+			}
 		}
 
 		if (Lights::IsIndicatorOn(pControlVeh)) {

--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -449,7 +449,7 @@ void Lights::Init()
 		}
 
 		CVehicle *pVeh = FindPlayerVehicle(-1, false);
-		if (pVeh && pVeh->IsDriver(FindPlayerPed()) && !Util::IsEngineOff(pVeh))
+		if (pVeh && pVeh->IsDriver(FindPlayerPed()))
 		{
 			static size_t prev = 0;
 			bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
@@ -466,14 +466,18 @@ void Lights::Init()
 				}
 			}
 
-			bool isHeadlightsActiveForLong = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime() || !Util::IsEngineOff(pVeh)) && !CarUtil::IsLightsForcedOff(pVeh);
+			VehLightDatav1 &data = m_VehData.Get(pVeh);
+			if (!isHeadlightsActive)
+			{
+				data.m_bLongLightsOn = false;
+			}
+
 			bool canToggleLongLights = !(gbProperShadersDetected && !gbLightPointLights);
-			if (Util::IsKeyPressed(g_nLongLightKey) && isHeadlightsActiveForLong && canToggleLongLights)
+			if (Util::IsKeyPressed(g_nLongLightKey) && isHeadlightsActive && canToggleLongLights)
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
 				if (now - prev > 500.0f)
 				{
-					VehLightDatav1 &data = m_VehData.Get(pVeh);
 					data.m_bLongLightsOn = !data.m_bLongLightsOn;
 					prev = now;
 					AudioMgr::PlaySwitchSound(pVeh);

--- a/src/features/lights/components/fog_light.cpp
+++ b/src/features/lights/components/fog_light.cpp
@@ -31,7 +31,7 @@ bool FogLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
 }
 
 void FogLightComponent::Process(CVehicle* pVeh, VehLightData& data) {
-    if (pVeh->IsDriver(FindPlayerPed()) && !Util::IsEngineOff(pVeh)) {
+    if (pVeh->IsDriver(FindPlayerPed())) {
         static size_t prev = 0;
         bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
         bool canToggleFogLight = !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;

--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -43,11 +43,15 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 }
 
 void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
-    if (pVeh->IsDriver(FindPlayerPed()) && !Util::IsEngineOff(pVeh)) {
+    if (pVeh->IsDriver(FindPlayerPed())) {
         static size_t prev = 0;
-        bool isHeadlightsActiveForLong = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime() || !Util::IsEngineOff(pVeh)) && !CarUtil::IsLightsForcedOff(pVeh);
+        bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
+        if (!isHeadlightsActive) {
+            data.bLongLightsOn = false;
+        }
+
         bool canToggleLongLights = !(gbProperShadersDetected && !LightsConfig::Get().gbLightPointLights);
-        if (Util::IsKeyPressed(LightsConfig::Get().nLongLightKey) && isHeadlightsActiveForLong && canToggleLongLights) {
+        if (Util::IsKeyPressed(LightsConfig::Get().nLongLightKey) && isHeadlightsActive && canToggleLongLights) {
             size_t now = CTimer::m_snTimeInMilliseconds;
             if (now - prev > 500.0f) {
                 data.bLongLightsOn = !data.bLongLightsOn;


### PR DESCRIPTION
### Summary

Previously, pressing the high beam key ('G') while vehicle headlights were completely turned off would still play the high beam relay click audio and turn on the high beam dashboard indicator LED, even though the physical headlights were unlit.

---

### Key Fixes

- **Headlight State Guard:**
  - High beam toggling now requires active headlights (either standard low beam or night-time automatic lights).
  - Toggling high beams while headlights are turned off is safely ignored.
- **Synchronized Audio & Dashboard LEDs:**
  - High beam switch sound (`light_switch.wav`) and dashboard high beam blue LED indicator only activate when headlights are active.
- **Lights v1 & v2 Parity:**
  - Implemented cleanly across both `Lights v1` (`StandardLights`) and `Lights v2` (`StandardLightsv2`).