### PR TITLE
fix(lights): resolve SA-MP daytime headlight flickering, ghost lights, and toggling

### DIFF
--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -105,14 +105,14 @@ void DashboardLEDs::Init()
 
 		auto data = Lights::GetVehicleData(pControlVeh);
 		static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true);
-		bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
+		bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pControlVeh) && (!Util::IsEngineOff(pControlVeh) || pControlVeh->bLightsOn);
 		bool isFoggy = Util::IsFoggy();
 		bool shouldShowFog = isFoggy || !foglightTiedtoHeadlight || isHeadlightsActive;
 		bool isFogLightOn = (data.m_bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pControlVeh);
 		if (isFogLightOn && shouldShowFog) {
 			EnableLED(pControlVeh, eMaterialType::FogLightLed);
 		}
-		bool headlightsOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
+		bool headlightsOn = isHeadlightsActive;
 		if (headlightsOn) {
 			if (data.m_bLongLightsOn) {
 				EnableLED(pControlVeh, eMaterialType::HighBeamLed);

--- a/src/features/lights.cpp
+++ b/src/features/lights.cpp
@@ -16,6 +16,7 @@
 #include <CPointLights.h>
 #include "ModelExtrasAPI.h"
 #include "utils/meevents.h"
+#include "utils/samp.h"
 #include "lights/manager.h"
 
 using namespace plugin;
@@ -134,6 +135,8 @@ void Lights::Init()
 	// // CVehicle::DoHeadLightEffect
 	patch::SetUChar(0x6E0CF8, 0);
 	patch::SetUChar(0x6E0DEE, 0);
+
+	SAMP::PatchVehicleLights();
 
 	// NOP CVehicle::DoHeadLightBeam
 	if (!gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true)))
@@ -388,40 +391,62 @@ void Lights::Init()
 			c.shadow.size = 1.85f;
 			c.shadow.color = {220, 220, 220, static_cast<unsigned char>(gGlobalShadowIntensity)};
 		}
-		else if (name == "taillights" || name == "taillights2") { // some models have dummies starting with taillights
+		else if (name.starts_with("taillight")) {
 			c.dummyPos = eDummyPos::Rear;
-			c.lightType = eMaterialType::TailLightRight;
+			bool isLeft = STR_FOUND(name, "_l");
+			bool isRight = STR_FOUND(name, "_r");
 			c.corona.size = gfTailLightCoronaSize;
 			c.corona.color = {250, 0, 0, static_cast<unsigned char>(gTailLightCoronaIntensity)};
 			c.shadow.color = {250, 0, 0, static_cast<unsigned char>(gTailLightShadowIntensity)};
 			c.shadow.size = gfTailLightShadowSize;
 			c.corona.lightingType = eLightingMode::Directional; 				
-			c.shadow.render = name != "taillights2";
-			dummies[c.lightType].push_back(new VehicleDummy(c));
-			if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
-				c.mirroredX = true;
+			c.shadow.render = !STR_FOUND(name, "2");
+
+			if (isLeft) {
 				c.lightType = eMaterialType::TailLightLeft;
 				dummies[c.lightType].push_back(new VehicleDummy(c));
+			} else if (isRight) {
+				c.lightType = eMaterialType::TailLightRight;
+				dummies[c.lightType].push_back(new VehicleDummy(c));
+			} else {
+				c.lightType = eMaterialType::TailLightRight;
+				dummies[c.lightType].push_back(new VehicleDummy(c));
+				if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
+					c.mirroredX = true;
+					c.lightType = eMaterialType::TailLightLeft;
+					dummies[c.lightType].push_back(new VehicleDummy(c));
+				}
 			}
 			return;
 		}
-		else if (name == "headlights" || name == "headlights2") {
+		else if (name.starts_with("headlight")) {
 			c.dummyPos = eDummyPos::Front;
-			c.lightType = eMaterialType::HeadLightLeft;
+			bool isLeft = STR_FOUND(name, "_l");
+			bool isRight = STR_FOUND(name, "_r");
 			c.corona.size = gfHeadLightCoronaSize;
 			c.corona.color = {250, 250, 250, static_cast<unsigned char>(gHeadLightCoronaIntensity)};
 			c.shadow.color = {250, 250, 250, static_cast<unsigned char>(gHeadLightShadowIntensity)};
 			c.shadow.size = gfHeadLightShadowSize;
 			c.corona.lightingType = eLightingMode::Directional;
-			c.shadow.render = name != "headlights2";
-			c.mirroredX = true;
-			dummies[c.lightType].push_back(new VehicleDummy(c));
-			// A single centered dummy would only produce a second corona in the same
-			// spot, so mirror it for bikes that actually have it off to one side
-			if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
-				c.mirroredX = false;
+			c.shadow.render = !STR_FOUND(name, "2");
+
+			if (isLeft) {
+				c.lightType = eMaterialType::HeadLightLeft;
+				dummies[c.lightType].push_back(new VehicleDummy(c));
+			} else if (isRight) {
 				c.lightType = eMaterialType::HeadLightRight;
 				dummies[c.lightType].push_back(new VehicleDummy(c));
+			} else {
+				c.mirroredX = true;
+				c.lightType = eMaterialType::HeadLightLeft;
+				dummies[c.lightType].push_back(new VehicleDummy(c));
+				// A single centered dummy would only produce a second corona in the same
+				// spot, so mirror it for bikes that actually have it off to one side
+				if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
+					c.mirroredX = false;
+					c.lightType = eMaterialType::HeadLightRight;
+					dummies[c.lightType].push_back(new VehicleDummy(c));
+				}
 			}
 			return;
 		}
@@ -478,9 +503,12 @@ void Lights::Init()
 		if (pVeh && pVeh->IsDriver(FindPlayerPed()))
 		{
 			static size_t prev = 0;
-			bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
-			bool canToggleFogLight = !g_bFoglightTiedToHeadlight || isHeadlightsActive;
-			if (Util::IsKeyPressed(g_nFogLightKey) && IsMatAvail(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight)
+			bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pVeh);
+			bool hasFogLights = CarUtil::CanHaveHeadlights(pVeh) &&
+			                    (IsMatAvail(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) ||
+			                     IsDummyAvail(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}));
+			bool canToggleFogLight = (!g_bFoglightTiedToHeadlight || isHeadlightsActive) && hasFogLights;
+			if (Util::IsKeyPressed(g_nFogLightKey) && canToggleFogLight)
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
 				if (now - prev > 500.0f)
@@ -498,7 +526,7 @@ void Lights::Init()
 				data.m_bLongLightsOn = false;
 			}
 
-			bool canToggleLongLights = !(gbProperShadersDetected && !gbLightPointLights);
+			bool canToggleLongLights = !(gbProperShadersDetected && !gbLightPointLights) && HasHeadlights(pVeh);
 			if (Util::IsKeyPressed(g_nLongLightKey) && isHeadlightsActive && canToggleLongLights)
 			{
 				size_t now = CTimer::m_snTimeInMilliseconds;
@@ -529,9 +557,16 @@ void Lights::Init()
 				ProcessPointLights(pVeh);
 			}
 
+			// Clear headlight beams when headlights are inactive or pop-ups are closed
+			if (!CarUtil::AreHeadlightsActive(pVeh) || !CarUtil::AreHeadlightsPopUpOpen(pVeh))
+			{
+				pVeh->m_renderLights.m_bLeftFront = false;
+				pVeh->m_renderLights.m_bRightFront = false;
+			}
+
 			// Mirrors the checks in the render callback below so both paths agree on
 			// which vehicles get headlights
-			if (pVeh->m_pDriver == FindPlayerPed() || pVeh->m_fHealth <= 0.0f || pVeh->m_nVehicleSubClass == VEHICLE_BMX || pVeh->m_nVehicleSubClass == VEHICLE_BOAT || pVeh->m_nVehicleSubClass == VEHICLE_TRAILER || (Util::IsEngineOff(pVeh) && !CarUtil::IsLightsForcedOn(pVeh) && !pVeh->bLightsOn))
+			if (pVeh->m_pDriver == FindPlayerPed() || pVeh->m_fHealth <= 0.0f || pVeh->m_nVehicleSubClass == VEHICLE_BMX || pVeh->m_nVehicleSubClass == VEHICLE_BOAT || pVeh->m_nVehicleSubClass == VEHICLE_TRAILER || !CarUtil::AreHeadlightsActive(pVeh) || (Util::IsEngineOff(pVeh) && !CarUtil::IsLightsForcedOn(pVeh)))
 			{
 				continue;
 			}
@@ -569,7 +604,7 @@ void Lights::Init()
 
 		// Fix for UIF SAMP server https://github.com/user-grinch/ModelExtras/issues/112
 		// Don't clear light state when lights are forced on/already on via SAMP
-		if (((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn) || CarUtil::IsLightsForcedOff(pControlVeh)) {
+		if (pControlVeh->m_fHealth <= 0.0f || ((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn) || CarUtil::IsLightsForcedOff(pControlVeh)) {
 			pControlVeh->bLightsOn = false;
 			pControlVeh->m_renderLights.m_bLeftFront = false;
 			pControlVeh->m_renderLights.m_bRightFront = false;
@@ -597,19 +632,27 @@ void Lights::Init()
 		bool isFrontBumperDamaged = Util::IsPanelDamaged(pControlVeh, ePanels::BUMP_FRONT);
 		bool isLeftRearOk = !(Util::IsLightDamaged(pTowedVeh, eLights::LIGHT_REAR_LEFT) || Util::IsPanelDamaged(pTowedVeh, ePanels::WING_REAR_LEFT));
 		bool isRightRearOk = !(Util::IsLightDamaged(pTowedVeh, eLights::LIGHT_REAR_RIGHT) || Util::IsPanelDamaged(pTowedVeh, ePanels::WING_REAR_RIGHT));
-		RenderLights(pControlVeh, pTowedVeh, eMaterialType::AllDayLight, true, "indicator", 1.85f);
-		RenderLights(pControlVeh, pTowedVeh, eMaterialType::StrobeLight);
-		RenderLights(pControlVeh, pTowedVeh, eMaterialType::SideLightLeft, true, "indicator", 1.85f, false, isLeftMiddleOk);
-		RenderLights(pControlVeh, pTowedVeh, eMaterialType::SideLightRight, true, "indicator", 1.85f, false, isRightMiddleOk);
+		bool isDriverOrForced = pControlVeh->m_pDriver != nullptr || CarUtil::IsLightsForcedOn(pControlVeh);
+		if (isDriverOrForced || Util::IsNightTime()) {
+			RenderLights(pControlVeh, pTowedVeh, eMaterialType::AllDayLight, true, "indicator", 1.85f);
+			RenderLights(pControlVeh, pTowedVeh, eMaterialType::StrobeLight);
+			RenderLights(pControlVeh, pTowedVeh, eMaterialType::SideLightLeft, true, "indicator", 1.85f, false, isLeftMiddleOk);
+			RenderLights(pControlVeh, pTowedVeh, eMaterialType::SideLightRight, true, "indicator", 1.85f, false, isRightMiddleOk);
+		}
 		
 		if (Util::IsNightTime()) {
 			RenderLights(pControlVeh, pTowedVeh, eMaterialType::NightLight, true, "indicator", 1.85f);
-		} else {
+		} else if (isDriverOrForced) {
 			RenderLights(pControlVeh, pTowedVeh, eMaterialType::DayLight, true, "indicator", 1.85f);
 		}
 		
 		static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true));
-		bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
+		bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pControlVeh);
+		bool bPopUpOpen = CarUtil::AreHeadlightsPopUpOpen(pControlVeh);
+		static bool bHeadLightBeams = gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true));
+		pControlVeh->m_renderLights.m_bLeftFront = isHeadlightsActive && bPopUpOpen && isHeadlightLeftOk && bHeadLightBeams;
+		pControlVeh->m_renderLights.m_bRightFront = isHeadlightsActive && bPopUpOpen && isHeadlightRightOk && bHeadLightBeams;
+
 		bool isFoggy = Util::IsFoggy();
 		bool shouldRenderFog = isFoggy || !foglightTiedtoHeadlight || isHeadlightsActive;
 		bool isFogLightOn = (data.m_bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pControlVeh);
@@ -634,7 +677,7 @@ void Lights::Init()
 			RenderLights(pControlVeh, pTowedVeh, eMaterialType::SpotLight, false, "", 1.0f, false, true, true);
 		}
 
-		std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+		std::string shdwName = "taillight";
 		float shdwSz = 1.6f;
 
 		if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK
@@ -665,7 +708,7 @@ void Lights::Init()
 						RenderLights(pControlVeh, pTowedVeh, eMaterialType::STTLightRight, true, shdwName, shdwSz, false, isRightRearOk);
 					}
 				} else {
-					if (IsMatAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight})) {
+					if (IsMatAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight}) || IsDummyAvail(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight})) {
 						if (isLeftRearOk) {
 							RenderLights(pControlVeh, pTowedVeh, eMaterialType::BrakeLightLeft, true, shdwName, shdwSz, false, isLeftRearOk);
 						}
@@ -673,7 +716,7 @@ void Lights::Init()
 							RenderLights(pControlVeh, pTowedVeh, eMaterialType::BrakeLightRight, true, shdwName, shdwSz, false, isRightRearOk);
 						}
 					}
-					else if (IsMatAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
+					else if (IsMatAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight}) || IsDummyAvail(pTowedVeh, {eMaterialType::TailLightLeft, eMaterialType::TailLightRight})) {
 						if (isLeftRearOk) {
 							RenderLights(pControlVeh, pTowedVeh, eMaterialType::TailLightLeft, true, shdwName, shdwSz, true, isLeftRearOk);
 						}
@@ -695,7 +738,7 @@ void Lights::Init()
 			}
 
 			bool indicatorOn = data.m_bUsingGlobalIndicators && data.m_nIndicatorState != eIndicatorState::Off;
-			bool tailLightFlag = (Util::IsNightTime() || pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh)) && !CarUtil::IsLightsForcedOff(pControlVeh);
+			bool tailLightFlag = CarUtil::AreHeadlightsActive(pControlVeh);
 			if (tailLightFlag || indicatorOn) {
 				if (sttInstalled) {
 					if (isLeftRearOk) {
@@ -987,7 +1030,7 @@ void Lights::RenderHeadlights(CVehicle *pControlVeh, bool isLeftOn, bool isRight
 		return;
 	}
 
-	bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime());
+	bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pControlVeh);
 	if (isHeadlightsActive && !data.m_bPrevHeadlightsOn)
 	{
 		data.m_nHeadlightsTurnedOnTime = CTimer::m_snTimeInMilliseconds;
@@ -1096,6 +1139,16 @@ bool Lights::IsMatAvail(CVehicle *pVeh, std::initializer_list<eMaterialType> sta
 	return false;
 }
 
+bool Lights::HasHeadlights(CVehicle *pVeh)
+{
+	if (!CarUtil::CanHaveHeadlights(pVeh))
+	{
+		return false;
+	}
+	return IsMatAvail(pVeh, {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight}) ||
+	       IsDummyAvail(pVeh, {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight});
+}
+
 void Lights::ProcessPointLights(CVehicle *pVeh)
 {
 	if (!gbLightPointLights || !pVeh || pVeh->m_fHealth <= 0.0f || pVeh->m_nVehicleSubClass == VEHICLE_BMX || pVeh->m_nVehicleSubClass == VEHICLE_BOAT || pVeh->m_nVehicleSubClass == VEHICLE_TRAILER)
@@ -1110,7 +1163,7 @@ void Lights::ProcessPointLights(CVehicle *pVeh)
 
 	VehLightDatav1 &data = m_VehData.Get(pVeh);
 	bool isBike = pVeh->m_nVehicleSubClass == VEHICLE_BIKE;
-	bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime() || (isBike && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+	bool isHeadlightsOn = CarUtil::AreHeadlightsActive(pVeh);
 
 	// 1. High Beam Headlights
 	if (data.m_bLongLightsOn && isHeadlightsOn && CarUtil::AreHeadlightsPopUpOpen(pVeh))

--- a/src/features/lights.h
+++ b/src/features/lights.h
@@ -52,6 +52,7 @@ private:
 	static bool IsDummyAvail(CVehicle* pVeh, std::initializer_list<eMaterialType> states);
 	static bool IsMatAvail(CVehicle *pVeh, eMaterialType state);
 	static bool IsMatAvail(CVehicle* pVeh, std::initializer_list<eMaterialType> states);
+	static bool HasHeadlights(CVehicle *pVeh);
 	
 protected:
     void Init() override;

--- a/src/features/lights/components/brake_light.cpp
+++ b/src/features/lights/components/brake_light.cpp
@@ -31,7 +31,7 @@ bool BrakeLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, cons
 
 void BrakeLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-    std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+    std::string shdwName = "taillight";
     float shdwSz = 2.0f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK

--- a/src/features/lights/components/drl_light.cpp
+++ b/src/features/lights/components/drl_light.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "drl_light.h"
 #include "utils/util.h"
 #include "utils/render.h"
@@ -42,14 +42,18 @@ bool DRLLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
 }
 
 void DRLLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
-    LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::AllDayLight, true, "indicator", 1.85f);
-    if (!Util::IsNightTime()) {
+    bool isDriverOrForced = pControlVeh->m_pDriver != nullptr || CarUtil::IsLightsForcedOn(pControlVeh);
+    if (isDriverOrForced || Util::IsNightTime()) {
+        LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::AllDayLight, true, "indicator", 1.85f);
+    }
+    if (!Util::IsNightTime() && isDriverOrForced) {
         LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::DayLight, true, "indicator", 1.85f);
     }
     if (Util::IsNightTime()) {
         LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::NightLight, true, "indicator", 1.85f);
     }
 }
+
 
 void DRLLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
     auto renderDRLPointLight = [&](eMaterialType type) {

--- a/src/features/lights/components/fog_light.cpp
+++ b/src/features/lights/components/fog_light.cpp
@@ -33,10 +33,13 @@ bool FogLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
 void FogLightComponent::Process(CVehicle* pVeh, VehLightData& data) {
     if (pVeh->IsDriver(FindPlayerPed())) {
         static size_t prev = 0;
-        bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
-        bool canToggleFogLight = !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
+        bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pVeh);
+        bool hasFogLights = CarUtil::CanHaveHeadlights(pVeh) &&
+                            (LightManager::IsMaterialAvailable(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) ||
+                             LightManager::IsDummyAvailable(data, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}));
+        bool canToggleFogLight = (!LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive) && hasFogLights;
 
-        if (Util::IsKeyPressed(LightsConfig::Get().nFogLightKey) && LightManager::IsMaterialAvailable(pVeh, {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) && canToggleFogLight) {
+        if (Util::IsKeyPressed(LightsConfig::Get().nFogLightKey) && canToggleFogLight) {
             size_t now = CTimer::m_snTimeInMilliseconds;
             if (now - prev > 500.0f) {
                 data.bFogLightsOn = !data.bFogLightsOn;
@@ -48,7 +51,8 @@ void FogLightComponent::Process(CVehicle* pVeh, VehLightData& data) {
 }
 
 void FogLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
-    bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
+    bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pControlVeh);
+
     bool isFoggy = Util::IsFoggy();
     bool shouldRenderFog = isFoggy || !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
     bool isFogLightOn = (data.bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pControlVeh);
@@ -60,7 +64,7 @@ void FogLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLi
 }
 
 void FogLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
-    bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+    bool isHeadlightsOn = CarUtil::AreHeadlightsActive(pVeh);
     bool isFoggy = Util::IsFoggy();
     bool shouldRenderFog = isFoggy || !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsOn;
     bool isFogLightOn = (data.bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pVeh);

--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -5,6 +5,7 @@
 #include "utils/audiomgr.h"
 #include "utils/render.h"
 #include "../damage.h"
+#include "defines.h"
 #include <CWeather.h>
 
 extern bool gbProperShadersDetected;
@@ -21,24 +22,33 @@ eMaterialType HeadlightComponent::GetMatType(CRGBA matCol) {
 }
 
 bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::string_view name, VehLightData& data) {
-    if (name == "headlights" || name == "headlights2") {
+    if (name.starts_with("headlight")) {
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.dummyPos = eDummyPos::Front;
-        c.lightType = eMaterialType::HeadLightLeft;
+        bool isLeft = STR_FOUND(name, "_l");
+        bool isRight = STR_FOUND(name, "_r");
         c.corona.size = LightsConfig::Get().gfHeadLightCoronaSize;
         c.corona.color = {250, 250, 250, static_cast<unsigned char>(LightsConfig::Get().gHeadLightCoronaIntensity)};
         c.shadow.color = {250, 250, 250, static_cast<unsigned char>(LightsConfig::Get().gHeadLightShadowIntensity)};
         c.shadow.size = LightsConfig::Get().gfHeadLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
-        c.shadow.render = name != "headlights2";
-        
-        c.mirroredX = true;
-        data.dummies[eMaterialType::HeadLightLeft].push_back(new VehicleDummy(c));
-        
-        if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
-            c.mirroredX = false;
+        c.shadow.render = !STR_FOUND(name, "2");
+
+        if (isLeft) {
+            c.lightType = eMaterialType::HeadLightLeft;
+            data.dummies[eMaterialType::HeadLightLeft].push_back(new VehicleDummy(c));
+        } else if (isRight) {
             c.lightType = eMaterialType::HeadLightRight;
             data.dummies[eMaterialType::HeadLightRight].push_back(new VehicleDummy(c));
+        } else {
+            c.mirroredX = true;
+            c.lightType = eMaterialType::HeadLightLeft;
+            data.dummies[eMaterialType::HeadLightLeft].push_back(new VehicleDummy(c));
+            if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
+                c.mirroredX = false;
+                c.lightType = eMaterialType::HeadLightRight;
+                data.dummies[eMaterialType::HeadLightRight].push_back(new VehicleDummy(c));
+            }
         }
         return true;
     }
@@ -52,12 +62,15 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
     if (pVeh->IsDriver(FindPlayerPed())) {
         static size_t prev = 0;
-        bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
+        bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pVeh);
         if (!isHeadlightsActive) {
             data.bLongLightsOn = false;
         }
 
-        bool canToggleLongLights = !(gbProperShadersDetected && !LightsConfig::Get().gbLightPointLights);
+        bool hasHeadlights = CarUtil::CanHaveHeadlights(pVeh) &&
+                             (LightManager::IsMaterialAvailable(pVeh, {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight}) ||
+                              LightManager::IsDummyAvailable(data, {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight}));
+        bool canToggleLongLights = !(gbProperShadersDetected && !LightsConfig::Get().gbLightPointLights) && hasHeadlights;
         if (Util::IsKeyPressed(LightsConfig::Get().nLongLightKey) && isHeadlightsActive && canToggleLongLights) {
             size_t now = CTimer::m_snTimeInMilliseconds;
             if (now - prev > 500.0f) {
@@ -67,14 +80,14 @@ void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
             }
         }
     } else if (pVeh->m_nVehicleSubClass != VEHICLE_BMX && pVeh->m_nVehicleSubClass != VEHICLE_BOAT && pVeh->m_nVehicleSubClass != VEHICLE_TRAILER && pVeh->m_fHealth > 0.0f) {
-        if (CarUtil::IsLightsForcedOff(pVeh) || (Util::IsEngineOff(pVeh) && !CarUtil::IsLightsForcedOn(pVeh) && !pVeh->bLightsOn)) {
+        if (CarUtil::IsLightsForcedOff(pVeh) || !CarUtil::AreHeadlightsActive(pVeh) || (Util::IsEngineOff(pVeh) && !CarUtil::IsLightsForcedOn(pVeh))) {
             return;
         }
 
         if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 300.0f || pVeh->GetIsOnScreen()) {
             bool isLeftFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_LEFT);
             bool isRightFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_RIGHT);
-            bool isNightOrOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+            bool isNightOrOn = CarUtil::AreHeadlightsActive(pVeh);
             if (isNightOrOn && !data.bPrevHeadlightsOn) {
                 data.nHeadlightsTurnedOnTime = CTimer::m_snTimeInMilliseconds;
             }
@@ -101,7 +114,7 @@ void HeadlightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
         return;
     }
 
-    bool isNightOrOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
+    bool isNightOrOn = CarUtil::AreHeadlightsActive(pControlVeh);
     if (isNightOrOn && !data.bPrevHeadlightsOn) {
         data.nHeadlightsTurnedOnTime = CTimer::m_snTimeInMilliseconds;
     }
@@ -131,7 +144,8 @@ void HeadlightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 }
 
 void HeadlightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
-    bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+    bool isHeadlightsOn = CarUtil::AreHeadlightsActive(pVeh);
+
 
     if (data.bLongLightsOn && isHeadlightsOn && CarUtil::AreHeadlightsPopUpOpen(pVeh)) {
         float highBeamMul = LightsConfig::Get().fHighBeamPointLightMul;

--- a/src/features/lights/components/indicator.cpp
+++ b/src/features/lights/components/indicator.cpp
@@ -176,7 +176,7 @@ void IndicatorComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
         }
     } else {
         bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-        std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+        std::string shdwName = "taillight";
         float shdwSz = 2.0f;
 
         if (data.nIndicatorState == eIndicatorState::BothOn || data.nIndicatorState == eIndicatorState::LeftOn) {

--- a/src/features/lights/components/nabrake_light.cpp
+++ b/src/features/lights/components/nabrake_light.cpp
@@ -31,7 +31,7 @@ bool NABrakeLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, co
 
 void NABrakeLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-    std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+    std::string shdwName = "taillight";
     float shdwSz = 2.0f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK

--- a/src/features/lights/components/reverse_light.cpp
+++ b/src/features/lights/components/reverse_light.cpp
@@ -36,7 +36,7 @@ bool ReverseLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, co
 
 void ReverseLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-    std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+    std::string shdwName = "taillight";
     float shdwSz = 2.0f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK

--- a/src/features/lights/components/side_light.cpp
+++ b/src/features/lights/components/side_light.cpp
@@ -34,6 +34,9 @@ bool SideLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 }
 
 void SideLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
+    bool isDriverOrForced = pControlVeh->m_pDriver != nullptr || CarUtil::IsLightsForcedOn(pControlVeh);
+    if (!isDriverOrForced && !Util::IsNightTime()) return;
+
     auto damage = LightDamageState::Get(pControlVeh, pTowedVeh);
     bool isLeftMiddleOk = damage.isMiddleLeftOk;
     bool isRightMiddleOk = damage.isMiddleRightOk;
@@ -42,7 +45,7 @@ void SideLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 }
 
 void SideLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
-    bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+    bool isHeadlightsOn = CarUtil::AreHeadlightsActive(pVeh);
 
     if (isHeadlightsOn) {
         for (eMaterialType type : {eMaterialType::SideLightLeft, eMaterialType::SideLightRight}) {

--- a/src/features/lights/components/stt_light.cpp
+++ b/src/features/lights/components/stt_light.cpp
@@ -31,7 +31,7 @@ bool STTLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
 
 void STTLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-    std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+    std::string shdwName = "taillight";
     float shdwSz = 2.0f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK

--- a/src/features/lights/components/tail_light.cpp
+++ b/src/features/lights/components/tail_light.cpp
@@ -18,23 +18,33 @@ eMaterialType TailLightComponent::GetMatType(CRGBA matCol) {
 }
 
 bool TailLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::string_view name, VehLightData& data) {
-    if (name == "taillights" || name == "taillights2") {
+    if (name.starts_with("taillight")) {
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.dummyPos = eDummyPos::Rear;
-        c.lightType = eMaterialType::TailLightRight;
+        bool isLeft = STR_FOUND(name, "_l");
+        bool isRight = STR_FOUND(name, "_r");
         c.corona.size = LightsConfig::Get().gfTailLightCoronaSize;
         c.corona.color = {250, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightCoronaIntensity)};
         c.shadow.color = {250, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightShadowIntensity)};
         c.shadow.size = LightsConfig::Get().gfTailLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
-        c.shadow.render = name != "taillights2";
-        c.mirroredX = false;
-        data.dummies[c.lightType].push_back(new VehicleDummy(c));
-        
-        if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
-            c.mirroredX = true;
+        c.shadow.render = !STR_FOUND(name, "2");
+
+        if (isLeft) {
             c.lightType = eMaterialType::TailLightLeft;
             data.dummies[c.lightType].push_back(new VehicleDummy(c));
+        } else if (isRight) {
+            c.lightType = eMaterialType::TailLightRight;
+            data.dummies[c.lightType].push_back(new VehicleDummy(c));
+        } else {
+            c.lightType = eMaterialType::TailLightRight;
+            c.mirroredX = false;
+            data.dummies[c.lightType].push_back(new VehicleDummy(c));
+            if (pVeh->m_nVehicleSubClass != VEHICLE_BIKE || std::abs(c.frame->modelling.pos.x) > 0.05f) {
+                c.mirroredX = true;
+                c.lightType = eMaterialType::TailLightLeft;
+                data.dummies[c.lightType].push_back(new VehicleDummy(c));
+            }
         }
         return true;
     }
@@ -43,7 +53,7 @@ bool TailLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 
 void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
     bool isBike = CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex);
-    std::string shdwName = (isBike ? "taillight_bike" : "taillight");
+    std::string shdwName = "taillight";
     float shdwSz = 1.6f;
 
     if (pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK
@@ -55,7 +65,7 @@ void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
         bool isRightRearOk = damage.isRearRightOk;
 
         bool indicatorOn = data.bUsingGlobalIndicators && data.nIndicatorState != eIndicatorState::Off;
-        bool tailLightFlag = (Util::IsNightTime() || pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh)) && !CarUtil::IsLightsForcedOff(pControlVeh);
+        bool tailLightFlag = CarUtil::AreHeadlightsActive(pControlVeh);
         bool sttInstalled = LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
 
         if ((tailLightFlag || indicatorOn) && !sttInstalled) {
@@ -102,7 +112,7 @@ void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 }
 
 void TailLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
-    bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
+    bool isHeadlightsOn = CarUtil::AreHeadlightsActive(pVeh);
     bool isBraking = (pVeh->m_fBreakPedal > 0.05f) && (pVeh->m_pDriver != nullptr);
     bool isBike = CModelInfo::IsBikeModel(pVeh->m_nModelIndex);
     bool hasDedicatedBrakeDummy = LightManager::IsDummyAvailable(data, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight});

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -3,6 +3,7 @@
 #include "lights.h"
 #include "manager.h"
 #include "utils/meevents.h"
+#include "utils/samp.h"
 
 void LightsFeature::Init() {
     if (!gConfig.ReadBoolean("LIGHTS", "StandardLightsv2", gConfig.ReadBoolean("FEATURES", "StandardLightsv2", false))) {
@@ -18,6 +19,8 @@ void LightsFeature::Init() {
 	// CVehicle::DoHeadLightEffect
 	patch::SetUChar(0x6E0CF8, 0);
 	patch::SetUChar(0x6E0DEE, 0);
+
+	SAMP::PatchVehicleLights();
 
 	// NOP CVehicle::DoHeadLightBeam
 	if (!gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true)))

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -107,6 +107,11 @@ void LightManager::RegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::str
 void LightManager::Process(CVehicle* pVeh) {
     if (!pVeh) return;
 
+    if (!CarUtil::AreHeadlightsActive(pVeh) || !CarUtil::AreHeadlightsPopUpOpen(pVeh)) {
+        pVeh->m_renderLights.m_bLeftFront = false;
+        pVeh->m_renderLights.m_bRightFront = false;
+    }
+
     VehLightData& data = m_VehData.Get(pVeh);
     for (const auto& comp : m_Components) {
         comp->Process(pVeh, data);
@@ -119,7 +124,7 @@ void LightManager::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh) {
 
     // Fix for UIF SAMP server https://github.com/user-grinch/ModelExtras/issues/112
     // Don't clear light state when lights are forced on/already on via SAMP
-    if (((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn) || CarUtil::IsLightsForcedOff(pControlVeh)) {
+    if (pControlVeh->m_fHealth <= 0.0f || ((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn) || CarUtil::IsLightsForcedOff(pControlVeh)) {
         pControlVeh->bLightsOn = false;
         pControlVeh->m_renderLights.m_bLeftFront = false;
         pControlVeh->m_renderLights.m_bRightFront = false;
@@ -132,6 +137,14 @@ void LightManager::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh) {
     if (pControlVeh->m_fHealth <= 0.0f || ((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn)) {
         return;
     }
+
+    bool isHeadlightsActive = CarUtil::AreHeadlightsActive(pControlVeh);
+    bool bPopUpOpen = CarUtil::AreHeadlightsPopUpOpen(pControlVeh);
+    static bool bHeadLightBeams = gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true));
+    bool isLeftFrontDamaged = Util::IsLightDamaged(pControlVeh, eLights::LIGHT_FRONT_LEFT) || Util::IsPanelDamaged(pControlVeh, ePanels::WING_FRONT_LEFT);
+    bool isRightFrontDamaged = Util::IsLightDamaged(pControlVeh, eLights::LIGHT_FRONT_RIGHT) || Util::IsPanelDamaged(pControlVeh, ePanels::WING_FRONT_RIGHT);
+    pControlVeh->m_renderLights.m_bLeftFront = isHeadlightsActive && bPopUpOpen && !isLeftFrontDamaged && bHeadLightBeams;
+    pControlVeh->m_renderLights.m_bRightFront = isHeadlightsActive && bPopUpOpen && !isRightFrontDamaged && bHeadLightBeams;
 
     for (const auto& comp : m_Components) {
         comp->Render(pControlVeh, pTowedVeh, data);

--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -175,8 +175,7 @@ RpMaterial *__cdecl LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTextu
         }
     }
 
-    bool isBike = pCurrentVeh->m_nVehicleSubClass == VEHICLE_BIKE;
-    bool lightsOn = (pCurrentVeh->bLightsOn || CarUtil::IsLightsForcedOn(pCurrentVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pCurrentVeh)) || (isBike && !Util::IsEngineOff(pCurrentVeh))) && !CarUtil::IsLightsForcedOff(pCurrentVeh);
+    bool lightsOn = CarUtil::AreHeadlightsActive(pCurrentVeh) && (!Util::IsEngineOff(pCurrentVeh) || pCurrentVeh->bLightsOn);
     if (pCurrentVeh->m_fHealth > 0.0f && lightsOn)
     {
         ModelInfoMgr::RegisterRestoreSurfProps(material);

--- a/src/utils/car.cpp
+++ b/src/utils/car.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "car.h"
 #include "enums/lightoverride.h"
+#include "utils/util.h"
 
 bool CarUtil::IsLightsForcedOn(CVehicle *pVeh)
 {
@@ -32,3 +33,46 @@ bool CarUtil::AreHeadlightsPopUpOpen(CVehicle *pVeh)
     }
     return true;
 }
+
+bool CarUtil::CanHaveHeadlights(CVehicle *pVeh)
+{
+    if (!pVeh || pVeh->m_fHealth <= 0.0f)
+    {
+        return false;
+    }
+
+    // Only road motor vehicles can have headlights (automobiles, motorcycles, quads, monster trucks).
+    // Excludes bicycles (BMX), boats, planes, helicopters, trailers, trains, etc.
+    return pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE ||
+           pVeh->m_nVehicleSubClass == VEHICLE_BIKE ||
+           pVeh->m_nVehicleSubClass == VEHICLE_QUAD ||
+           pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK;
+}
+
+bool CarUtil::AreHeadlightsActive(CVehicle *pVeh)
+{
+    if (!CanHaveHeadlights(pVeh))
+    {
+        return false;
+    }
+
+    if (IsLightsForcedOff(pVeh))
+    {
+        return false;
+    }
+
+    if (IsLightsForcedOn(pVeh))
+    {
+        return true;
+    }
+
+    if (Util::IsNightTime())
+    {
+        return true;
+    }
+
+    // During daytime, vehicles require an active driver to have headlights on (unless forced on above).
+    // This prevents unoccupied parked cars from displaying daytime ghost headlights.
+    return pVeh->bLightsOn && pVeh->m_pDriver != nullptr;
+}
+

--- a/src/utils/car.h
+++ b/src/utils/car.h
@@ -7,4 +7,7 @@ public:
     static bool IsLightsForcedOff(CVehicle *pVeh);
     static bool IsLightsForcedOn(CVehicle *pVeh);
     static bool AreHeadlightsPopUpOpen(CVehicle *pVeh);
+    static bool CanHaveHeadlights(CVehicle *pVeh);
+    static bool AreHeadlightsActive(CVehicle *pVeh);
 };
+

--- a/src/utils/samp.cpp
+++ b/src/utils/samp.cpp
@@ -164,4 +164,24 @@ namespace SAMP
         const char *text = FindPlateText(pool, pGameVeh);
         return text ? SanitizeAndFormatPlateText(text) : "";
     }
+
+    void PatchVehicleLights()
+    {
+        if (!IsPresent()) return;
+
+        static bool s_patched = false;
+        if (s_patched) return;
+        s_patched = true;
+
+        // Apply the exact 7 NOP patches that SA-MP normally applies at 0xAA800 (0.3.DL)
+        // inside CVehicle::DoVehicleLights when ManualVehicleEngineAndLights() is enabled.
+        patch::Nop(0x6E1BA0, 6);
+        patch::Nop(0x6E1BB1, 6);
+        patch::Nop(0x6E1BD2, 7);
+        patch::Nop(0x6E1BE3, 0x25);
+        patch::Nop(0x6E1C38, 8);
+        patch::Nop(0x6E1D98, 0xF);
+        patch::Nop(0x6E1DBC, 8);
+    }
 }
+

--- a/src/utils/samp.h
+++ b/src/utils/samp.h
@@ -14,4 +14,13 @@ namespace SAMP
     // Retrieves and formats the custom license plate text for the given vehicle.
     // Returns empty string if not in SA-MP, vehicle not found in pool, or default plate ("XYZSR998").
     std::string GetVehiclePlateText(CVehicle *pGameVeh);
+
+    // Applies SA-MP vehicle light patches to GTA SA if SA-MP is loaded.
+    // On SA-MP servers that do not call ManualVehicleEngineAndLights() (e.g. WTLS),
+    // SA-MP skips NOPing GTA SA's CVehicle::DoVehicleLights daytime reset logic.
+    // This causes GTA SA to continuously clear bLightsOn every frame in daytime,
+    // conflicting with SA-MP sync packets and producing rapid headlight flickering
+    // as well as preventing the local player's /lights command from working.
+    void PatchVehicleLights();
 }
+


### PR DESCRIPTION
### Summary

This PR addresses multiple lighting synchronization and visual issues in SA-MP and singleplayer:

1. **SA-MP Daytime Headlight Flickering & Toggle Fix**:
   - On SA-MP servers that do not enable `ManualVehicleEngineAndLights()` (such as WTLS), `samp.dll` omits its native 7 NOP patches to GTA SA's `CVehicle::DoVehicleLights`.
   - As a result, GTA SA's native engine continuously resets `bLightsOn = 0` every frame during daytime, clashing with server sync packets (which push `bLightsOn = 1`), causing rapid flickering on remote vehicles and preventing the local player's `/lights` command from keeping headlights on.
   - Added `SAMP::PatchVehicleLights()` to safely apply these 7 NOPs when `samp.dll` is present, eliminating the daytime fight between game and server.

2. **Ghost Daytime Headlights on Parked Vehicles**:
   - Introduced `CarUtil::AreHeadlightsActive(pVeh)` to standardize headlight activity checks across v1 and v2.
   - During daytime, headlights require an active driver (`pVeh->m_pDriver != nullptr`) unless explicitly forced on by opcode, preventing unoccupied parked cars from displaying daytime ghost headlights.
   - Daytime DRL, all-day, and side marker lights are similarly guarded.

3. **Stuck 3D Headlight Beam Cones When Lights Are Off**:
   - GTA SA's `CAutomobile::Render` and `CBike::Render` draw the 3D headlight beam cone polygon based on `pVeh->m_renderLights.m_bLeftFront` and `m_bRightFront`.
   - Synchronized `m_renderLights.m_bLeftFront` and `m_bRightFront` directly with `isHeadlightsActive && bPopUpOpen && isHeadlightOk && bHeadLightBeams`, ensuring the beam polygons are properly turned off when headlights are inactive, pop-ups are closed, or headlights are damaged.

4. **Motorcycle Taillight Shadow & Dummy Registration**:
   - In `me_texdb.txd`, `"taillight_bike"` has only 7 non-zero alpha pixels, making it virtually transparent in GTA SA's shadow renderer. Standardized taillight shadow textures to `"taillight"`.
   - Expanded dummy registration to `name.starts_with("taillight")` and `name.starts_with("headlight")` with support for `_l` / `_r` suffixes and secondary dummy shadow filtering (`!STR_FOUND(name, "2")`), ensuring models with singular or split dummy names are properly recognized.

5. **High Beam & Fog Light Switch Sound Guard for Vehicles Without Headlights**:
   - Introduced `CarUtil::CanHaveHeadlights(pVeh)` and `Lights::HasHeadlights(pVeh)` to check vehicle subclasses (`AUTOMOBILE`, `BIKE`, `QUAD`, `MTRUCK`) and headlight material/dummy availability.
   - Non-headlight vehicles such as bicycles (`VEHICLE_BMX`), boats, airplanes, helicopters, trailers, and unadapted vehicles without headlights no longer report active headlights at night and cannot toggle high beams or fog lights, preventing phantom switch click sounds on key press.