### PR TITLE
fix(data): resolve jsonc loading failure, dummy node matching and weather conditions

### DIFF
--- a/src/features/sirens.cpp
+++ b/src/features/sirens.cpp
@@ -606,7 +606,9 @@ int GetSirenIndex(CVehicle *pVeh, RpMaterial *pMat)
 
 void Sirens::Init()
 {
-	DataMgr::RegisterListener("sirens", Sirens::Parse);
+	DataMgr::RegisterListener("sirens", [](int model, const nlohmann::json &data) {
+		Sirens::Parse(data, model);
+	});
 
 	ReloadConfig();
 	ModelInfoMgr::RegisterMaterial([](CVehicle *pVeh, RpMaterial *pMat)

--- a/src/utils/stringutil.cpp
+++ b/src/utils/stringutil.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "stringutil.h"
+#include <algorithm>
+#include <cctype>
 #include <regex>
 #include <sstream>
 
@@ -10,10 +12,9 @@ bool StringUtil::IsNumber(const std::string &s)
 
 std::optional<int> StringUtil::GetDigitsAfter(const std::string_view str, const std::string_view prefix)
 {
-    size_t pos = str.find(prefix);
-    if (pos == std::string_view::npos) return std::nullopt;
+    if (!str.starts_with(prefix)) return std::nullopt;
 
-    pos += prefix.length();
+    size_t pos = prefix.length();
     if (pos < str.length() && (str[pos] == '_' || str[pos] == '-')) {
         pos++;
     }
@@ -34,16 +35,18 @@ std::optional<int> StringUtil::GetDigitsAfter(const std::string_view str, const 
 
 std::optional<std::string> StringUtil::GetCharsAfterPrefix(const std::string_view str, const std::string_view prefix, size_t num_chars)
 {
-    size_t pos = str.find(prefix);
-    if (pos == std::string_view::npos) return std::nullopt;
+    if (!str.starts_with(prefix)) return std::nullopt;
 
-    pos += prefix.length();
+    size_t pos = prefix.length();
     if (pos < str.length() && (str[pos] == '_' || str[pos] == '-')) {
         pos++;
     }
 
     if (pos + num_chars <= str.length()) {
-        return std::string(str.substr(pos, num_chars));
+        std::string result(str.substr(pos, num_chars));
+        std::transform(result.begin(), result.end(), result.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+        return result;
     }
     return std::nullopt;
 }

--- a/src/utils/worldutil.cpp
+++ b/src/utils/worldutil.cpp
@@ -10,5 +10,5 @@ bool WorldUtil::IsNightTime()
 
 bool WorldUtil::IsFoggy()
 {
-    return (CWeather::Foggyness > 0.1f) || (CWeather::Rain > 0.3f) || (CWeather::NewWeatherType == WEATHER_FOGGY_SF || CWeather::NewWeatherType == WEATHER_SANDSTORM_DESERT || CWeather::OldWeatherType == WEATHER_FOGGY_SF || CWeather::OldWeatherType == WEATHER_SANDSTORM_DESERT);
+    return (CWeather::Foggyness > 0.1f) || (CWeather::NewWeatherType == WEATHER_FOGGY_SF || CWeather::NewWeatherType == WEATHER_SANDSTORM_DESERT || CWeather::OldWeatherType == WEATHER_FOGGY_SF || CWeather::OldWeatherType == WEATHER_SANDSTORM_DESERT);
 }


### PR DESCRIPTION
### Problem

1. **JSONC Loading Failure**: Commit `f008770` introduced `DataMgr::RegisterListener("sirens", Sirens::Parse);`. However, `ModelDataListener_t` signature is `void(int model, const nlohmann::json &data)` while `Sirens::Parse` signature is `void(const nlohmann::json &data, int model)`. When invoked in `DataMgr::LoadFile`, `jsonData` was passed as `int model`, causing `nlohmann::json` to throw `type_error.302: type must be number, but is object`. The exception was caught by `LoadFile`, completely aborting `.jsonc` configuration loading for all vehicles.
2. **Left-Side Dummy Reversal**: `StringUtil::GetCharsAfterPrefix` omitted uppercase conversion (`std::toupper`). Light components (`nabrake_light.cpp`, `side_light.cpp`, `stt_light.cpp`) compare extracted suffix against `"L"` (`d == "L"`). In models with standard lowercase dummy node names (`_l`), `"l" == "L"` evaluated to `false`, erroneously assigning left-side lights to the right side.
3. **Dummy Substring Matching**: `StringUtil::GetDigitsAfter` and `GetCharsAfterPrefix` used `str.find` instead of `str.starts_with`, causing non-dummy chassis/body nodes containing prefixes anywhere in their names to be falsely registered as active light dummies.
4. **Rain in Fog Check**: `WorldUtil::IsFoggy` triggered fog lights on ambient vehicles in rainy weather (`Rain > 0.3f`), which does not represent true low-visibility fog or sandstorms.

### Solution

1. Wrapped `Sirens::Parse` in a lambda `[](int model, const nlohmann::json &data) { Sirens::Parse(data, model); }` matching `Carcols::Init`.
2. Restored `!str.starts_with(prefix)` in `StringUtil::GetDigitsAfter` and `StringUtil::GetCharsAfterPrefix`.
3. Restored `std::toupper` transform in `StringUtil::GetCharsAfterPrefix` so both lowercase and uppercase suffixes (`_l` / `_L`) match correctly.
4. Removed rain condition from `WorldUtil::IsFoggy()`, keeping desert sandstorms and fog presets.