### PR TITLE
fix(core): add null guards for vehicle pointers in render setup

### DIFF
--- a/src/features/plate.cpp
+++ b/src/features/plate.cpp
@@ -148,6 +148,10 @@ RpMaterial *__cdecl LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTextu
 {
     if (plateType == -1)
     {
+        if (!pCurrentVeh)
+        {
+            return material;
+        }
         PlateData &data = m_VehData.Get(pCurrentVeh);
         if (data.cityId == -1)
         {

--- a/src/utils/modelinfomgr.cpp
+++ b/src/utils/modelinfomgr.cpp
@@ -228,6 +228,9 @@ void ModelInfoMgr::RegisterMaterialColProvider(
 }
 
 void ModelInfoMgr::SetupRender(CVehicle *ptr) {
+  if (!ptr) {
+    return;
+  }
   pCurVeh = ptr;
   auto &data = m_VehData.Get(pCurVeh);
   ptr->SetupRender();


### PR DESCRIPTION
### Problem
1. When `ModelInfoMgr::SetupRender(CVehicle *ptr)` was called with a null pointer (e.g. during certain world rendering passes or detached object/component setups), dereferencing `ptr->SetupRender()` caused an immediate access violation crash:
   ```
   Unhandled exception at 0x06B41E06 in modelextras.asi (+0x71e06): 0xC0000005: Access violation reading location 0x00000024.
   ```
2. In `LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTexture`, calling `m_VehData.Get(pCurrentVeh)` when `pCurrentVeh` was not yet initialized or null resulted in null pointer dereference crashes.

### Solution
1. Added early null guard in `ModelInfoMgr::SetupRender`: `if (!ptr) { return; }`.
2. Added null guard in `LicensePlate::CCustomCarPlateMgr_SetupMaterialPlatebackTexture`: `if (!pCurrentVeh) { return material; }`.