### PR TITLE
feat(lights): add player idle brake lights with coasting and throttle safety

### DIFF
--- a/resource/dist/ModelExtras.ini
+++ b/resource/dist/ModelExtras.ini
@@ -45,6 +45,7 @@ SpotLights                           = 1            # Spotlights for emergency v
 AutoIndicatorsOnSteer                = 0            # Automatically activates turn indicators while steering
 StandardLights_GlobalIndicatorLights = 1            # Renders indicator (turn) lights for non-adapted vehicles
 FoglightTiedToHeadlight              = 1            # Fog lights will only turn on when headlights are active
+PlayerIdleBrakeLights                = 0            # Automatically keep player vehicle brake lights on while stopped and idling
 LightCoronaSize                      = 0.3          # Base size for standard light coronas
 LightCoronaIntensity                 = 80           # Opacity and brightness of standard light coronas (0 - 255)
 CoronaDistanceMul                    = 0.1          # Scales coronas at distance during night time (0.0 to disable)

--- a/src/features/lights/components/brake_light.cpp
+++ b/src/features/lights/components/brake_light.cpp
@@ -38,7 +38,7 @@ void BrakeLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, Veh
         || pControlVeh->m_nVehicleSubClass == VEHICLE_QUAD || pControlVeh->m_nVehicleSubClass == VEHICLE_BIKE
         || pControlVeh->m_nVehicleSubClass == VEHICLE_TRAILER) 
     {
-        bool brakeOn = pControlVeh->m_fBreakPedal && pControlVeh->m_pDriver;
+        bool brakeOn = LightManager::IsBraking(pControlVeh);
         if (brakeOn) {
             auto damage = LightDamageState::Get(pControlVeh, pTowedVeh);
             bool isLeftRearOk = damage.isRearLeftOk;

--- a/src/features/lights/components/nabrake_light.cpp
+++ b/src/features/lights/components/nabrake_light.cpp
@@ -42,7 +42,7 @@ void NABrakeLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, V
         bool isLeftRearOk = damage.isRearLeftOk;
         bool isRightRearOk = damage.isRearRightOk;
 
-        bool brakeOn = pControlVeh->m_fBreakPedal && pControlVeh->m_pDriver;
+        bool brakeOn = LightManager::IsBraking(pControlVeh);
         if (brakeOn && data.nIndicatorState != eIndicatorState::BothOn) {
             if (data.nIndicatorState != eIndicatorState::LeftOn && isLeftRearOk) {
                 LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::NABrakeLightLeft, true, shdwName, shdwSz, false, isLeftRearOk);

--- a/src/features/lights/components/stt_light.cpp
+++ b/src/features/lights/components/stt_light.cpp
@@ -42,7 +42,7 @@ void STTLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLi
         bool isLeftRearOk = damage.isRearLeftOk;
         bool isRightRearOk = damage.isRearRightOk;
 
-        bool brakeOn = pControlVeh->m_fBreakPedal && pControlVeh->m_pDriver;
+        bool brakeOn = LightManager::IsBraking(pControlVeh);
         bool indicatorOn = data.bUsingGlobalIndicators && data.nIndicatorState != eIndicatorState::Off;
         bool tailOn = (Util::IsNightTime() || pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || indicatorOn) && !CarUtil::IsLightsForcedOff(pControlVeh);
         

--- a/src/features/lights/components/tail_light.cpp
+++ b/src/features/lights/components/tail_light.cpp
@@ -61,7 +61,7 @@ void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
         if ((tailLightFlag || indicatorOn) && !sttInstalled) {
             bool hasDedicatedBrake = LightManager::IsMaterialAvailable(pTowedVeh, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight}) ||
                                      LightManager::IsDummyAvailable(data, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
-            bool isBraking = (pControlVeh->m_fBreakPedal > 0.05f) && (pControlVeh->m_pDriver != nullptr);
+            bool isBraking = LightManager::IsBraking(pControlVeh);
             bool tailHighlight = !hasDedicatedBrake && isBraking;
 
             auto tailLightsRender = [&](bool leftOk, bool rightOk) {
@@ -103,7 +103,7 @@ void TailLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 
 void TailLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
     bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
-    bool isBraking = (pVeh->m_fBreakPedal > 0.05f) && (pVeh->m_pDriver != nullptr);
+    bool isBraking = LightManager::IsBraking(pVeh);
     bool isBike = CModelInfo::IsBikeModel(pVeh->m_nModelIndex);
     bool hasDedicatedBrakeDummy = LightManager::IsDummyAvailable(data, {eMaterialType::BrakeLightLeft, eMaterialType::BrakeLightRight, eMaterialType::STTLightLeft, eMaterialType::STTLightRight, eMaterialType::NABrakeLightLeft, eMaterialType::NABrakeLightRight});
 

--- a/src/features/lights/data.h
+++ b/src/features/lights/data.h
@@ -49,6 +49,7 @@ struct LightsConfig {
     uint32_t nIndicatorBothKey = 'X';
     bool bAutoIndicatorsOnSteer = false;
     bool bFoglightTiedToHeadlight = false;
+    bool bPlayerIdleBrakeLights = false;
     float fHighBeamPointLightMul = 2.0f;
 
     void InitConfig() {
@@ -79,6 +80,7 @@ struct LightsConfig {
         nIndicatorBothKey = gConfig.ReadInteger("KEYS", "IndicatorLightBothKey", 'X');
         bAutoIndicatorsOnSteer = gConfig.ReadBoolean("LIGHTS", "AutoIndicatorsOnSteer", gConfig.ReadBoolean("TWEAKS", "AutoIndicatorsOnSteer", false));
         bFoglightTiedToHeadlight = gConfig.ReadBoolean("LIGHTS", "FoglightTiedToHeadlight", gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", false));
+        bPlayerIdleBrakeLights = gConfig.ReadBoolean("LIGHTS", "PlayerIdleBrakeLights", gConfig.ReadBoolean("TWEAKS", "PlayerIdleBrakeLights", false));
         
         float rawMul = gConfig.ReadFloat("LIGHTS", "HighBeamPointLightMul", gConfig.ReadFloat("TWEAKS", "HighBeamPointLightMul", 2.0f));
         fHighBeamPointLightMul = (rawMul < 1.0f) ? 1.0f : ((rawMul > 4.0f) ? 4.0f : rawMul);

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -269,3 +269,30 @@ void LightManager::Reload(CVehicle* pVeh) {
         DataMgr::Reload(pVeh->m_nModelIndex);
     }
 }
+
+bool LightManager::IsBraking(CVehicle* pVeh) {
+    if (!pVeh || !pVeh->m_pDriver) {
+        return false;
+    }
+
+    if (pVeh->m_fBreakPedal > 0.05f) {
+        return true;
+    }
+
+    if (LightsConfig::Get().bPlayerIdleBrakeLights) {
+        CPed* pPlayer = FindPlayerPed();
+        if (pPlayer && pVeh->IsDriver(pPlayer)) {
+            if (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK || 
+                pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_BIKE) 
+            {
+                if (!CarUtil::IsEngineOff(pVeh) && pVeh->m_fHealth > 0.0f) {
+                    if (pVeh->m_fGasPedal <= 0.05f && CarUtil::GetVehicleSpeed(pVeh) < 0.5f) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/features/lights/manager.h
+++ b/src/features/lights/manager.h
@@ -33,8 +33,6 @@ public:
     static void Reload(CVehicle* pVeh);
     static bool GetLightState(CVehicle* pVeh, eMaterialType lightId) { return m_VehData.Get(pVeh).bLightStates[lightId]; }
     static void SetLightState(CVehicle* pVeh, eMaterialType lightId, bool state) { m_VehData.Get(pVeh).bLightStates[lightId] = state; }
-    static bool IsIndicatorOn(CVehicle* pVeh) {
-        return pVeh && pVeh->m_fHealth > 0.0f && (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_BIKE || pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK) && BlinkerState::Get().bIndicatorsDelay && m_VehData.Get(pVeh).nIndicatorState != eIndicatorState::Off;
-    }
+    static bool IsIndicatorOn(CVehicle* pVeh);
     static bool IsBraking(CVehicle* pVeh);
 };

--- a/src/features/lights/manager.h
+++ b/src/features/lights/manager.h
@@ -36,4 +36,5 @@ public:
     static bool IsIndicatorOn(CVehicle* pVeh) {
         return pVeh && pVeh->m_fHealth > 0.0f && (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_BIKE || pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK) && BlinkerState::Get().bIndicatorsDelay && m_VehData.Get(pVeh).nIndicatorState != eIndicatorState::Off;
     }
+    static bool IsBraking(CVehicle* pVeh);
 };


### PR DESCRIPTION
Resolves #272

### Summary
Adds an optional feature (`PlayerIdleBrakeLights`) that automatically keeps the player vehicle's brake lights illuminated while stopped and idling, matching real-world automatic transmission behavior and GTA SA NPC traffic vehicle behavior.

### Behavior & Details
- **Disabled by default**: Configured in `ModelExtras.ini` under `[LIGHTS]` (`PlayerIdleBrakeLights = 0`).
- **Coasting**: When releasing throttle while driving (either forward or backward), the vehicle coasts freely and brake lights remain **OFF** (`GetVehicleSpeed >= 0.5f`).
- **Standstill Idle**: When the vehicle comes to a complete stop (`GetVehicleSpeed < 0.5f`) with pedals released, idle brake lights turn **ON** (works both after driving forward and after reversing).
- **Throttle Takeoff**: As soon as the gas pedal is pressed (`m_fGasPedal > 0.05f`), brake lights turn **OFF** immediately.
- **Driver & State Checks**: Only applies to motorized land vehicles (`AUTOMOBILE`, `MTRUCK`, `QUAD`, `BIKE`) driven by the player when the engine is running (`!CarUtil::IsEngineOff`) and vehicle health > 0. Turns off immediately if the player exits.
- **Component Parity**: Integrated seamlessly into `LightManager::IsBraking()` across standard brake lights, non-adaptive brake lights, STT lights, and tail light highlighting/point lights.