### PR TITLE
fix(core): relocate heliRenderEvent hook from CEntity to CHeli and guard vehicle types

### DIFF
--- a/src/utils/meevents.h
+++ b/src/utils/meevents.h
@@ -7,7 +7,7 @@ namespace MEEvents
 {
     using namespace plugin;
     // vehicle
-    static inline ThiscallEvent<AddressList<0x5343B2, H_CALL>, PRIORITY_AFTER, ArgPickN<CVehicle *, 0>, void(CVehicle *)> heliRenderEvent;
+    static inline ThiscallEvent<AddressList<0x6C4523, H_CALL>, PRIORITY_AFTER, ArgPickN<CVehicle *, 0>, void(CVehicle *)> heliRenderEvent;
     static inline ThiscallEvent<AddressList<0x6D0E89, H_JUMP>, PRIORITY_BEFORE, ArgPickN<CVehicle *, 0>, void(CVehicle *)> vehRenderEvent;
     // CAutomobile::PreRender only. Bikes go through the processScriptsEvent loop in each
     // feature instead, CBike::PreRender has no equivalent call site to hook here.

--- a/src/utils/modelinfomgr.cpp
+++ b/src/utils/modelinfomgr.cpp
@@ -130,7 +130,7 @@ void ModelInfoMgr::Init() {
   patch::ReplaceFunction(
       0x4C8460, reinterpret_cast<void *>(ModelInfoMgr::ResetEditableMaterials));
   MEEvents::vehRenderEvent.before += [](CVehicle *pVeh) {
-    if (!pVeh || !pVeh->m_pRwClump) {
+    if (!pVeh || pVeh->m_nType != ENTITY_TYPE_VEHICLE || !pVeh->m_pRwClump) {
       return;
     }
 
@@ -147,8 +147,25 @@ void ModelInfoMgr::Init() {
   };
 
   MEEvents::heliRenderEvent.after += [](CVehicle *pVeh) {
-    if (pVeh && CModelInfo::IsHeliModel(pVeh->m_nModelIndex)) {
-      ModelInfoMgr::OnRender(pVeh);
+    if (!pVeh || pVeh->m_nType != ENTITY_TYPE_VEHICLE) {
+      return;
+    }
+
+    uint16_t modelIndex = static_cast<uint16_t>(pVeh->m_nModelIndex);
+    if (CModelInfo::IsHeliModel(modelIndex)) {
+      if (!pVeh->m_pRwClump) {
+        return;
+      }
+      auto &data = m_VehData.Get(pVeh);
+      if (data.nFrameCount > 10) {
+        ModelInfoMgr::OnRender(pVeh);
+      } else if (data.nFrameCount == 10) {
+        ModelInfoMgr::FindDummies(
+            pVeh, reinterpret_cast<RwFrame *>(pVeh->m_pRwClump->object.parent));
+        data.nFrameCount++;
+      } else {
+        data.nFrameCount++;
+      }
     }
   };
 }


### PR DESCRIPTION
### Summary
Fixes an Access Violation crash (`0xC0000005` at `0x004C5B10` in `CModelInfo::IsHeliModel`) that occurs in total conversion mods or expanded limit configurations (such as **SAxVCxLC**) when rendering map objects/buildings with model IDs above 32,767.

### Root Cause
1. In `src/utils/meevents.h`, `heliRenderEvent` was hooked at `0x5343B2` (`call CEntity::RenderEffects` inside `CEntity::Render`).
2. `CEntity::Render()` is the base render routine for **all non-vehicle world entities** (buildings, objects, roads, and dummies) across the entire map. As a result, every rendered map entity was triggering `heliRenderEvent` and being passed to the lambda as a `CVehicle*`.
3. In `src/utils/modelinfomgr.cpp`, the callback queried `CModelInfo::IsHeliModel(pVeh->m_nModelIndex)`.
4. Because `CEntity::m_nModelIndex` is defined as a signed 16-bit `short`, any model ID > 32,767 (e.g. 34,569 = `0x8709`) sign-extends to a negative integer (`-30,967` / `0xFFFF8709`).
5. `CModelInfo::IsHeliModel` indexed `ms_modelInfoPtrs` with that negative index, causing an immediate crash.

### Changes
1. **Hook Relocation (`src/utils/meevents.h`)**:
   - Moved `heliRenderEvent` from `0x5343B2` to `0x6C4523` (`call CEntity::Render` at the tail of `CHeli::Render`).
   - `0x6C4523` is **exclusively called for helicopters**, eliminating tens of thousands of redundant event firings per frame on map objects and significantly improving rendering performance.
2. **Defensive Entity Guards (`src/utils/modelinfomgr.cpp`)**:
   - Added `pVeh->m_nType == ENTITY_TYPE_VEHICLE` checks to both `vehRenderEvent` and `heliRenderEvent`.
   - Cast `m_nModelIndex` to unsigned `uint16_t` before calling `CModelInfo::IsHeliModel()`.
   - Added standard 10-frame dummy registration (`ModelInfoMgr::FindDummies`) for helicopters.