### PR TITLE
fix(lights): update global indicators (allow mtruck, exclude bikes)

### DIFF
--- a/src/features/lights/components/indicator.cpp
+++ b/src/features/lights/components/indicator.cpp
@@ -98,6 +98,20 @@ static inline float GetZAngleForPoint(CVector2D const &point) {
 void IndicatorComponent::Process(CVehicle* pVeh, VehLightData& data) {
     static bool bSAMP = GetModuleHandle("samp.dll") != nullptr;
 
+    bool hasIndicators = data.bUsingGlobalIndicators ||
+                         LightManager::IsMaterialAvailable(pVeh, INDICATOR_LIGHTS_TYPE) ||
+                         LightManager::IsDummyAvailable(data, INDICATOR_LIGHTS_TYPE) ||
+                         LightManager::IsMaterialAvailable(pVeh, {eMaterialType::STTLightLeft, eMaterialType::STTLightRight}) ||
+                         (LightsConfig::Get().gbGlobalIndicatorLights &&
+                          (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK) &&
+                          !CModelInfo::IsBikeModel(pVeh->m_nModelIndex) &&
+                          pVeh->GetVehicleAppearance() == VEHICLE_APPEARANCE_AUTOMOBILE);
+
+    if (!hasIndicators) {
+        data.nIndicatorState = eIndicatorState::Off;
+        return;
+    }
+
     if (pVeh->IsDriver(FindPlayerPed()) &&
         (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_BIKE || pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK))
     {
@@ -169,8 +183,9 @@ void IndicatorComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 
     // Global turn lights activation check
     if (LightsConfig::Get().gbGlobalIndicatorLights && !LightManager::IsMaterialAvailable(pControlVeh, INDICATOR_LIGHTS_TYPE) && !LightManager::IsMaterialAvailable(pControlVeh, {eMaterialType::STTLightLeft, eMaterialType::STTLightRight})) {
-        if ((pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_BIKE || pControlVeh->m_nVehicleSubClass == VEHICLE_QUAD) &&
-            (pControlVeh->GetVehicleAppearance() == VEHICLE_APPEARANCE_AUTOMOBILE || pControlVeh->GetVehicleAppearance() == VEHICLE_APPEARANCE_BIKE) &&
+        if ((pControlVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pControlVeh->m_nVehicleSubClass == VEHICLE_MTRUCK) &&
+            !CModelInfo::IsBikeModel(pControlVeh->m_nModelIndex) &&
+            (pControlVeh->GetVehicleAppearance() == VEHICLE_APPEARANCE_AUTOMOBILE) &&
             pControlVeh->bEngineOn && pControlVeh->m_fHealth > 0 && !pControlVeh->bIsDrowning && !pControlVeh->m_pAttachedTo) {
             data.bUsingGlobalIndicators = true;
         }

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -247,6 +247,23 @@ bool LightManager::IsMaterialAvailable(CVehicle* pVeh, std::initializer_list<eMa
     return false;
 }
 
+bool LightManager::IsIndicatorOn(CVehicle* pVeh) {
+    if (!pVeh || pVeh->m_fHealth <= 0.0f || !BlinkerState::Get().bIndicatorsDelay) {
+        return false;
+    }
+    if ((pVeh->m_nVehicleSubClass != VEHICLE_AUTOMOBILE && pVeh->m_nVehicleSubClass != VEHICLE_MTRUCK) || CModelInfo::IsBikeModel(pVeh->m_nModelIndex)) {
+        return false;
+    }
+    VehLightData& data = m_VehData.Get(pVeh);
+    if (data.nIndicatorState == eIndicatorState::Off) {
+        return false;
+    }
+    return data.bUsingGlobalIndicators ||
+           IsMaterialAvailable(pVeh, INDICATOR_LIGHTS_TYPE) ||
+           IsDummyAvailable(data, INDICATOR_LIGHTS_TYPE) ||
+           IsMaterialAvailable(pVeh, {eMaterialType::STTLightLeft, eMaterialType::STTLightRight});
+}
+
 void LightManager::ProcessPointLights(CVehicle *pVeh) {
     if (!LightsConfig::Get().gbLightPointLights || !pVeh || pVeh->m_fHealth <= 0.0f || pVeh->m_nVehicleSubClass == VEHICLE_BMX || pVeh->m_nVehicleSubClass == VEHICLE_BOAT || pVeh->m_nVehicleSubClass == VEHICLE_TRAILER) {
         return;

--- a/src/features/lights/manager.h
+++ b/src/features/lights/manager.h
@@ -33,7 +33,5 @@ public:
     static void Reload(CVehicle* pVeh);
     static bool GetLightState(CVehicle* pVeh, eMaterialType lightId) { return m_VehData.Get(pVeh).bLightStates[lightId]; }
     static void SetLightState(CVehicle* pVeh, eMaterialType lightId, bool state) { m_VehData.Get(pVeh).bLightStates[lightId] = state; }
-    static bool IsIndicatorOn(CVehicle* pVeh) {
-        return pVeh && pVeh->m_fHealth > 0.0f && (pVeh->m_nVehicleSubClass == VEHICLE_AUTOMOBILE || pVeh->m_nVehicleSubClass == VEHICLE_BIKE || pVeh->m_nVehicleSubClass == VEHICLE_QUAD || pVeh->m_nVehicleSubClass == VEHICLE_MTRUCK) && BlinkerState::Get().bIndicatorsDelay && m_VehData.Get(pVeh).nIndicatorState != eIndicatorState::Off;
-    }
+    static bool IsIndicatorOn(CVehicle* pVeh);
 };


### PR DESCRIPTION
### Problem
1. When `GlobalIndicatorLights = 1` was enabled, motorcycles and bikes (`VEHICLE_BIKE` and `CModelInfo::IsBikeModel`) were erroneously matched for car-style global indicator activation even when they possessed no actual turn signals.
2. Monster trucks (`VEHICLE_MTRUCK`) were unintentionally omitted from global indicators in both `indicator.cpp` and `manager.cpp`.
3. In `IndicatorComponent::Process`, if a vehicle lacked valid indicators (materials, dummies, STT lights, or global indicators), `data.nIndicatorState` was not reset to `Off`.

### Solution
1. Moved `LightManager::IsIndicatorOn(CVehicle* pVeh)` implementation out of `manager.h` into `manager.cpp`, verifying indicator availability via `bUsingGlobalIndicators`, materials, and dummies.
2. Included `VEHICLE_MTRUCK` and explicitly excluded bikes (`!CModelInfo::IsBikeModel`) from global indicator eligibility.
3. Added early check in `IndicatorComponent::Process` resetting `nIndicatorState = eIndicatorState::Off` when no indicators are available on the vehicle.