### PR TITLE
fix(lights): ensure pop-up headlights opening delay works for all vehicles

### DIFF
--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -20,8 +20,38 @@ eMaterialType HeadlightComponent::GetMatType(CRGBA matCol) {
     return eMaterialType::UnknownMaterial;
 }
 
+static bool CanVehicleHaveHeadlights(CVehicle* pVeh) {
+    if (!pVeh) return false;
+    int model = pVeh->m_nModelIndex;
+    if (CModelInfo::IsBmxModel(model) || CModelInfo::IsBoatModel(model) || CModelInfo::IsTrailerModel(model) || CModelInfo::IsHeliModel(model) || CModelInfo::IsPlaneModel(model)) {
+        return false;
+    }
+    if (pVeh->m_nVehicleSubClass == VEHICLE_BMX || pVeh->m_nVehicleSubClass == VEHICLE_BOAT || pVeh->m_nVehicleSubClass == VEHICLE_TRAILER || pVeh->m_nVehicleSubClass == VEHICLE_HELI || pVeh->m_nVehicleSubClass == VEHICLE_PLANE) {
+        return false;
+    }
+    return true;
+}
+
+bool HeadlightComponent::AreHeadlightsOpen(CVehicle* pVeh, const VehLightData& data) {
+    if (!pVeh || pVeh->m_nVehicleSubClass != VEHICLE_AUTOMOBILE) {
+        return true;
+    }
+
+    CAutomobile* pAuto = static_cast<CAutomobile*>(pVeh);
+    bool hasPopUp = (pAuto->m_aCarNodes[CAR_MISC_A] != nullptr) || data.bHasVehFuncsPopUp;
+    if (!hasPopUp) {
+        return true;
+    }
+
+    return pAuto->m_renderLights.m_bLeftFront || pAuto->m_renderLights.m_bRightFront || pAuto->m_fPropRotate >= 0.68f;
+}
+
 bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::string_view name, VehLightData& data) {
+    if (!CanVehicleHaveHeadlights(pVeh)) return false;
     if (name == "headlights" || name == "headlights2") {
+        if (pFrame && !rwLinkListEmpty(&pFrame->objectList)) {
+            return false;
+        }
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.dummyPos = eDummyPos::Front;
         c.lightType = eMaterialType::HeadLightLeft;
@@ -42,7 +72,14 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
         }
         return true;
     }
-    if (name.starts_with("f_pop")) {
+
+    std::string lowerName;
+    lowerName.reserve(name.size());
+    for (char ch : name) {
+        lowerName.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+    }
+
+    if (lowerName.find("f_pop") != std::string::npos || lowerName.find("popup") != std::string::npos) {
         data.bHasVehFuncsPopUp = true;
         return true;
     }
@@ -50,9 +87,10 @@ bool HeadlightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const
 }
 
 void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
+    if (!CanVehicleHaveHeadlights(pVeh)) return;
+
+    bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
     if (pVeh->IsDriver(FindPlayerPed())) {
-        static size_t prev = 0;
-        bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pVeh);
         if (!isHeadlightsActive) {
             data.bLongLightsOn = false;
         }
@@ -70,14 +108,8 @@ void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
         if (CVector::Distance(pVeh->GetPosition(), TheCamera.GetPosition()) < 300.0f || pVeh->GetIsOnScreen()) {
             bool isLeftFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_LEFT);
             bool isRightFrontOk = !Util::IsLightDamaged(pVeh, eLights::LIGHT_FRONT_RIGHT);
-            bool isNightOrOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
-            if (isNightOrOn && !data.bPrevHeadlightsOn) {
-                data.nHeadlightsTurnedOnTime = CTimer::m_snTimeInMilliseconds;
-            }
-            data.bPrevHeadlightsOn = isNightOrOn;
 
-            bool isVehFuncsOpening = data.bHasVehFuncsPopUp && (CTimer::m_snTimeInMilliseconds - data.nHeadlightsTurnedOnTime < 800);
-            if (isNightOrOn && CarUtil::AreHeadlightsPopUpOpen(pVeh) && !isVehFuncsOpening) {
+            if (isHeadlightsActive && AreHeadlightsOpen(pVeh, data)) {
                 bool isFoggy = Util::IsFoggy();
                 std::string texName = data.bLongLightsOn ? "headlight_long" : "headlight_short";
                 bool shadow = !gbProperShadersDetected;
@@ -92,19 +124,12 @@ void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
 }
 
 void HeadlightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) {
-    int model = pControlVeh->m_nModelIndex;
-    if (CModelInfo::IsTrailerModel(model) || CarUtil::IsLightsForcedOff(pControlVeh) || CModelInfo::IsBmxModel(model) || CModelInfo::IsBoatModel(model) || CModelInfo::IsHeliModel(model) || CModelInfo::IsPlaneModel(model) || !CarUtil::AreHeadlightsPopUpOpen(pControlVeh)) {
+    if (!CanVehicleHaveHeadlights(pControlVeh)) {
         return;
     }
 
     bool isNightOrOn = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
-    if (isNightOrOn && !data.bPrevHeadlightsOn) {
-        data.nHeadlightsTurnedOnTime = CTimer::m_snTimeInMilliseconds;
-    }
-    data.bPrevHeadlightsOn = isNightOrOn;
-
-    bool isVehFuncsOpening = data.bHasVehFuncsPopUp && (CTimer::m_snTimeInMilliseconds - data.nHeadlightsTurnedOnTime < 800);
-    if (!isNightOrOn || isVehFuncsOpening) return;
+    if (!isNightOrOn || !AreHeadlightsOpen(pControlVeh, data)) return;
 
     auto damage = LightDamageState::Get(pControlVeh, pTowedVeh);
     bool isHeadlightLeftOk = damage.isHeadlightLeftOk;
@@ -127,9 +152,10 @@ void HeadlightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
 }
 
 void HeadlightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
+    if (!CanVehicleHaveHeadlights(pVeh)) return;
     bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh)) || (pVeh->m_nVehicleSubClass == VEHICLE_BIKE && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
 
-    if (data.bLongLightsOn && isHeadlightsOn && CarUtil::AreHeadlightsPopUpOpen(pVeh)) {
+    if (data.bLongLightsOn && isHeadlightsOn && AreHeadlightsOpen(pVeh, data)) {
         float highBeamMul = LightsConfig::Get().fHighBeamPointLightMul;
 
         for (eMaterialType type : {eMaterialType::HeadLightLeft, eMaterialType::HeadLightRight}) {

--- a/src/features/lights/components/headlight.h
+++ b/src/features/lights/components/headlight.h
@@ -11,4 +11,6 @@ public:
     void Process(CVehicle* pVeh, VehLightData& data) override;
     void Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLightData& data) override;
     void ProcessPointLights(CVehicle* pVeh, VehLightData& data) override;
+
+    static bool AreHeadlightsOpen(CVehicle* pVeh, const VehLightData& data);
 };

--- a/src/features/lights/data.h
+++ b/src/features/lights/data.h
@@ -125,8 +125,6 @@ struct VehLightData {
     bool bLightStates[eMaterialType::TotalMaterial];
     unsigned int nHeadlightTickFrame = 0;
     bool bHasVehFuncsPopUp = false;
-    unsigned int nHeadlightsTurnedOnTime = 0;
-    bool bPrevHeadlightsOn = false;
 
     VehLightData(CVehicle* pVeh = nullptr) {
         std::fill(std::begin(bLightStates), std::end(bLightStates), true);
@@ -148,8 +146,6 @@ struct VehLightData {
             bUsingGlobalIndicators = other.bUsingGlobalIndicators;
             bWasAutoSteerActive = other.bWasAutoSteerActive;
             bHasVehFuncsPopUp = other.bHasVehFuncsPopUp;
-            nHeadlightsTurnedOnTime = other.nHeadlightsTurnedOnTime;
-            bPrevHeadlightsOn = other.bPrevHeadlightsOn;
             dummies = std::move(other.dummies);
             for (auto& vec : other.dummies) {
                 vec.clear();
@@ -164,6 +160,7 @@ struct VehLightData {
         for (auto& vec : dummies) {
             vec.clear();
         }
+        bHasVehFuncsPopUp = false;
     }
     
     ~VehLightData() {

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -94,10 +94,21 @@ eMaterialType LightManager::GetMatType(RpMaterial* pMat) {
 }
 
 void LightManager::RegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const std::string_view name) {
-    if (pFrame && !rwLinkListEmpty(&pFrame->objectList)) {
+    if (!pVeh || !pFrame) return;
+
+    VehLightData& data = m_VehData.Get(pVeh);
+
+    if (!rwLinkListEmpty(&pFrame->objectList)) {
+        // Pop-up headlights are animated geometry frames (RpAtomic attached), not empty dummies.
+        // Only HeadlightComponent inspects non-empty frames to detect pop-up lights.
+        for (const auto& comp : m_Components) {
+            if (dynamic_cast<HeadlightComponent*>(comp.get())) {
+                comp->TryRegisterDummy(pVeh, pFrame, name, data);
+                break;
+            }
+        }
         return;
     }
-    VehLightData& data = m_VehData.Get(pVeh);
 
     for (const auto& comp : m_Components) {
         if (comp->TryRegisterDummy(pVeh, pFrame, name, data)) return;


### PR DESCRIPTION
### Problem
1. Non-empty RwFrames (frames with `RpAtomic` attached) were unconditionally skipped in `LightManager::RegisterDummy`, preventing pop-up headlight frames (`f_pop` or `popup`) on VehFuncs and custom vehicles from being recognized because they contain animated geometry rather than empty dummies.
2. Headlight coronas, shadows, and pointlights were using a hardcoded 800ms timer rather than checking actual physical pop-up door rotation and light render state, causing light to leak through closed covers on slower opening animations or vehicles with different timing.
3. Headlight dummy registration did not guard against non-headlight vehicle subclasses (boats, planes, BMX, trailers).

### Solution
1. In `LightManager::RegisterDummy`, inspect non-empty frames specifically via `HeadlightComponent::TryRegisterDummy` so pop-up frames are properly detected without breaking dummy registration for other components.
2. In `headlight.cpp`, introduced `HeadlightComponent::AreHeadlightsOpen(pVeh, data)` which checks:
   - Whether the vehicle has pop-up headlights (`CAR_MISC_A` or `data.bHasVehFuncsPopUp`).
   - If present, verifies that the headlight doors are physically open (`m_renderLights.m_bLeftFront || m_renderLights.m_bRightFront || m_fPropRotate >= 0.68f`).
3. Guarded `Process`, `Render`, `TryRegisterDummy`, and `ProcessPointLights` with `CanVehicleHaveHeadlights(pVeh)`.