### PR TITLE
feat(exhaust): reduce default smoke lifetime from 1.0 to 0.4

### DIFF
--- a/src/features/exhausts.h
+++ b/src/features/exhausts.h
@@ -21,7 +21,7 @@ struct ExhaustData
     std::string sName;
     RwFrame *pFrame = nullptr;
     CRGBA Color = {150, 150, 150, 200}; // Dark grey default
-    float fLifeTime = 1.0f;             // Longer lifetime for larger pipes
+    float fLifeTime = 0.4f;             // Default smoke lifetime (shortened to prevent excessive rising)
     float fSpeedMul = 1.0f;             // Speed multiplier
     float fSizeMul = 1.0f;
     bool bNitroEffect = true;


### PR DESCRIPTION
### Summary
Reduces the default exhaust smoke particle lifetime `fLifeTime` from `1.0f` to `0.4f` in `src/features/exhausts.h`.

### Rationale
A `1.0f` particle lifetime caused vehicle exhaust smoke to linger and rise unnaturally high into the air behind the vehicle like a smokestack. A `0.4f` duration produces realistic, authentic exhaust smoke puffs that dissipate naturally behind the car.