### PR TITLE
feat(lights): add per-vehicle inertia fade for all light types with proper shadow and material support

### DIFF
--- a/src/features/core/dummy.cpp
+++ b/src/features/core/dummy.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "dummy.h"
 #include "defines.h"
+#include "features/lights/manager.h"
 #include "utils/datamgr.h"
 #include "enums/dummypos.h"
 #include <CWorld.h>
@@ -48,15 +49,30 @@ VehicleDummy::VehicleDummy(const DummyConfig& config)
     if (jsonData.contains("lights"))
     {
         std::string newName(name.substr(0, name.find("_prm")));
+        const nlohmann::json* pLightsSec = nullptr;
         if (jsonData["lights"].contains(newName))
         {
-            auto &lights = jsonData["lights"][newName];
+            pLightsSec = &jsonData["lights"][newName];
+        }
+        else
+        {
+            const char* fallbackKey = LightManager::GetLightGroupKey(data.lightType);
+            if (fallbackKey && jsonData["lights"].contains(fallbackKey))
+            {
+                pLightsSec = &jsonData["lights"][fallbackKey];
+            }
+        }
+
+        if (pLightsSec)
+        {
+            auto &lights = *pLightsSec;
 
             if (lights.contains("corona"))
             {
                 auto &coronaSec = lights["corona"];
                 if (coronaSec.contains("color"))
                 {
+                    data.hasCustomColor = true;
                     data.corona.color.r = coronaSec["color"].value("red", data.corona.color.r);
                     data.corona.color.g = coronaSec["color"].value("green", data.corona.color.g);
                     data.corona.color.b = coronaSec["color"].value("blue", data.corona.color.b);
@@ -82,6 +98,19 @@ VehicleDummy::VehicleDummy(const DummyConfig& config)
 
                 // shadows will be force enabled if there is JSON data for it.
                 data.shadow.render = true;
+            }
+
+            if (lights.contains("inertia"))
+            {
+                data.inertia = lights.value("inertia", 0.0f);
+            }
+
+            // Inherit corona color to shadow if no explicit shadow color was set
+            if (data.hasCustomColor && !(lights.contains("shadow") && lights["shadow"].contains("color")))
+            {
+                data.shadow.color.r = data.corona.color.r;
+                data.shadow.color.g = data.corona.color.g;
+                data.shadow.color.b = data.corona.color.b;
             }
 
             // Only for StrobeLights

--- a/src/features/core/dummyconfig.h
+++ b/src/features/core/dummyconfig.h
@@ -22,6 +22,8 @@ struct DummyConfig {
     bool isParentDummy = false;
     // Set when the frame hangs off the chassis, so it is rolled by the bike lean
     bool leanAffected = false;
+    bool hasCustomColor = false;
+    float inertia = 0.0f;
     
     struct {
         float angle = 0.0f;

--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -91,7 +91,7 @@ void HeadlightComponent::Process(CVehicle* pVeh, VehLightData& data) {
 
     bool isHeadlightsActive = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
     if (pVeh->IsDriver(FindPlayerPed())) {
-        if (!isHeadlightsActive) {
+        if (!isHeadlightsActive && data.fLightFactor[eMaterialType::HeadLightLeft] <= 0.001f) {
             data.bLongLightsOn = false;
         }
 

--- a/src/features/lights/data.h
+++ b/src/features/lights/data.h
@@ -118,6 +118,7 @@ using LightsGlobal = LightsConfig;
 struct VehLightData {
     bool bFogLightsOn = false;
     bool bLongLightsOn = false;
+    float fHighBeamFactor = 0.0f;
     eIndicatorState nIndicatorState = eIndicatorState::Off;
     bool bUsingGlobalIndicators = false;
     bool bWasAutoSteerActive = false;
@@ -127,9 +128,13 @@ struct VehLightData {
     bool bLightStates[eMaterialType::TotalMaterial];
     unsigned int nHeadlightTickFrame = 0;
     bool bHasVehFuncsPopUp = false;
+    std::array<float, eMaterialType::TotalMaterial> fLightFactor = {};
+    std::array<bool, eMaterialType::TotalMaterial> bLightRenderedThisFrame = {};
 
     VehLightData(CVehicle* pVeh = nullptr) {
         std::fill(std::begin(bLightStates), std::end(bLightStates), true);
+        fLightFactor.fill(0.0f);
+        bLightRenderedThisFrame.fill(false);
     }
 
     VehLightData(const VehLightData&) = delete;
@@ -144,10 +149,13 @@ struct VehLightData {
             ClearDummies();
             bFogLightsOn = other.bFogLightsOn;
             bLongLightsOn = other.bLongLightsOn;
+            fHighBeamFactor = other.fHighBeamFactor;
             nIndicatorState = other.nIndicatorState;
             bUsingGlobalIndicators = other.bUsingGlobalIndicators;
             bWasAutoSteerActive = other.bWasAutoSteerActive;
             bHasVehFuncsPopUp = other.bHasVehFuncsPopUp;
+            fLightFactor = other.fLightFactor;
+            bLightRenderedThisFrame = other.bLightRenderedThisFrame;
             dummies = std::move(other.dummies);
             for (auto& vec : other.dummies) {
                 vec.clear();
@@ -162,6 +170,9 @@ struct VehLightData {
         for (auto& vec : dummies) {
             vec.clear();
         }
+        fLightFactor.fill(0.0f);
+        fHighBeamFactor = 0.0f;
+        bLightRenderedThisFrame.fill(false);
         bHasVehFuncsPopUp = false;
     }
     

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -3,6 +3,7 @@
 #include "lights.h"
 #include "manager.h"
 #include "utils/meevents.h"
+#include "utils/datamgr.h"
 #include "ModelExtrasAPI.h"
 
 float gfGlobalCoronaSize = 0.3f;
@@ -46,6 +47,62 @@ void Lights::Init() {
 
 	ModelInfoMgr::RegisterDummy([](CVehicle *pVeh, RwFrame *pFrame, const std::string_view nodeName) {
         LightManager::RegisterDummy(pVeh, pFrame, nodeName);
+    });
+
+    ModelInfoMgr::RegisterMaterialColProvider([](CVehicle *pVeh, RpMaterial *pMat, eMaterialType type) -> MatStateColor {
+        if (!m_bEnabled || !pVeh || type < 0 || type >= eMaterialType::TotalMaterial) {
+            return MatStateColor{DEFAULT_MAT_COL, DEFAULT_MAT_COL};
+        }
+        VehLightData &data = LightManager::m_VehData.Get(pVeh);
+        if (LightManager::IsDummyAvailable(data, type)) {
+            const DummyConfig &c = data.dummies[type][0]->GetRef();
+            if (c.hasCustomColor) {
+                return MatStateColor{c.corona.color, DEFAULT_MAT_COL};
+            }
+        }
+
+        auto &json = DataMgr::Get(pVeh->m_nModelIndex);
+        if (json.contains("lights")) {
+            auto &lights = json["lights"];
+            auto CheckCol = [&](const char *key) -> std::optional<CRGBA> {
+                if (lights.contains(key) && lights[key].contains("corona") && lights[key]["corona"].contains("color")) {
+                    auto &c = lights[key]["corona"]["color"];
+                    CRGBA col;
+                    col.r = c.value("red", 255);
+                    col.g = c.value("green", 255);
+                    col.b = c.value("blue", 255);
+                    col.a = 255;
+                    return col;
+                }
+                return std::nullopt;
+            };
+
+            std::optional<CRGBA> col;
+            switch (type) {
+            case eMaterialType::HeadLightLeft: col = CheckCol("headlight_l"); if (!col) col = CheckCol("headlights"); break;
+            case eMaterialType::HeadLightRight: col = CheckCol("headlight_r"); if (!col) col = CheckCol("headlights"); break;
+            case eMaterialType::TailLightLeft: col = CheckCol("taillight_l"); if (!col) col = CheckCol("taillights"); break;
+            case eMaterialType::TailLightRight: col = CheckCol("taillight_r"); if (!col) col = CheckCol("taillights"); break;
+            case eMaterialType::BrakeLightLeft: case eMaterialType::NABrakeLightLeft: col = CheckCol("brakelight_l"); if (!col) col = CheckCol("brakelights"); break;
+            case eMaterialType::BrakeLightRight: case eMaterialType::NABrakeLightRight: col = CheckCol("brakelight_r"); if (!col) col = CheckCol("brakelights"); break;
+            case eMaterialType::ReverseLightLeft: col = CheckCol("reverselight_l"); if (!col) col = CheckCol("reverselights"); break;
+            case eMaterialType::ReverseLightRight: col = CheckCol("reverselight_r"); if (!col) col = CheckCol("reverselights"); break;
+            case eMaterialType::IndicatorLightLeftFront: col = CheckCol("indicator_lf"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::IndicatorLightRightFront: col = CheckCol("indicator_rf"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::IndicatorLightLeftRear: col = CheckCol("indicator_lr"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::IndicatorLightRightRear: col = CheckCol("indicator_rr"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::IndicatorLightLeftMiddle: col = CheckCol("indicator_lm"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::IndicatorLightRightMiddle: col = CheckCol("indicator_rm"); if (!col) col = CheckCol("indicators"); break;
+            case eMaterialType::FogLightLeft: col = CheckCol("foglight_l"); if (!col) col = CheckCol("fogl_l"); if (!col) col = CheckCol("foglights"); break;
+            case eMaterialType::FogLightRight: col = CheckCol("foglight_r"); if (!col) col = CheckCol("fogl_r"); if (!col) col = CheckCol("foglights"); break;
+            default: break;
+            }
+            if (col) {
+                return MatStateColor{*col, DEFAULT_MAT_COL};
+            }
+        }
+
+        return MatStateColor{DEFAULT_MAT_COL, DEFAULT_MAT_COL};
     });
 
 	MEEvents::vehPreRenderEvent.before += [](CVehicle *pVeh)

--- a/src/features/lights/manager.cpp
+++ b/src/features/lights/manager.cpp
@@ -103,6 +103,11 @@ void LightManager::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh) {
     VehLightData& data = m_VehData.Get(pControlVeh);
     eIndicatorState indState = data.nIndicatorState;
 
+    data.bLightRenderedThisFrame.fill(false);
+    if (pControlVeh != pTowedVeh) {
+        m_VehData.Get(pTowedVeh).bLightRenderedThisFrame.fill(false);
+    }
+
     // Fix for UIF SAMP server https://github.com/user-grinch/ModelExtras/issues/112
     // Don't clear light state when lights are forced on/already on via SAMP
     if (((Util::IsEngineOff(pControlVeh) && indState == eIndicatorState::Off) && !CarUtil::IsLightsForcedOn(pControlVeh) && !pControlVeh->bLightsOn) || CarUtil::IsLightsForcedOff(pControlVeh)) {
@@ -122,25 +127,108 @@ void LightManager::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh) {
     for (const auto& comp : m_Components) {
         comp->Render(pControlVeh, pTowedVeh, data);
     }
+
+    auto ProcessFadeOut = [](CVehicle* pVeh, VehLightData& vData) {
+        for (int t = 0; t < eMaterialType::TotalMaterial; ++t) {
+            eMaterialType type = static_cast<eMaterialType>(t);
+            if (!vData.bLightRenderedThisFrame[type] && vData.fLightFactor[type] > 0.001f) {
+                float inertia = GetLightInertia(pVeh, vData, type);
+                if (inertia > 0.01f) {
+                    float step = (CTimer::ms_fTimeStep / 50.0f) / inertia;
+                    vData.fLightFactor[type] = std::max(0.0f, vData.fLightFactor[type] - step);
+                } else {
+                    vData.fLightFactor[type] = 0.0f;
+                }
+
+                if (vData.fLightFactor[type] > 0.001f) {
+                    float factor = vData.fLightFactor[type];
+                    ModelInfoMgr::EnableMaterial(pVeh, type);
+
+                    int id = static_cast<int>(type) * 1000;
+                    for (auto& dummy : vData.dummies[type]) {
+                        const DummyConfig& c = dummy->GetRef();
+                        dummy->Update();
+                        RwFrame *parent = RwFrameGetParent(dummy->Get().frame);
+                        bool isBike = pVeh->m_nVehicleSubClass == VEHICLE_BIKE;
+                        bool isDamaged = Util::IsFrameDamaged(pVeh, parent) || !FrameUtil::IsOkAtomicVisible(parent);
+                        bool atomicCheck = !isBike && pVeh->GetIsOnScreen() && type != eMaterialType::HeadLightLeft && type != eMaterialType::HeadLightRight && isDamaged;
+                        if (atomicCheck || (c.dummyPos == eDummyPos::Rear && pVeh->m_pTrailer)) continue;
+
+                        float szMul = 1.0f;
+                        if (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) {
+                            szMul = 1.0f + 2.0f * vData.fHighBeamFactor;
+                        }
+                        EnableDummy((int)pVeh + 42 + id++, &dummy, pVeh, szMul, factor);
+
+                        if (c.shadow.render && factor > 0.01f) {
+                            std::string tex = c.shadow.texture.empty() ? (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight ? ((vData.fHighBeamFactor > 0.3f) ? "headlight_long" : "headlight_short") : "") : c.shadow.texture;
+                            if (!tex.empty()) {
+                                float sz = (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) ? LightsConfig::Get().headlightSz : 1.0f;
+                                RenderUtil::RegisterShadowDirectional(&dummy->Get(), tex, sz * c.shadow.size, factor);
+                            }
+                        }
+                    }
+                } else {
+                    if (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) {
+                        vData.fHighBeamFactor = 0.0f;
+                        vData.bLongLightsOn = false;
+                    }
+                }
+            }
+        }
+    };
+
+    ProcessFadeOut(pControlVeh, data);
+    if (pControlVeh != pTowedVeh) {
+        ProcessFadeOut(pTowedVeh, m_VehData.Get(pTowedVeh));
+    }
 }
 
-void LightManager::EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMul) {
-    if (LightsConfig::Get().gbLightCoronasFeature) {
-        const DummyConfig &c = dummy->GetRef();
+void LightManager::EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMul, float alphaMul) {
+    if (LightsConfig::Get().gbLightCoronasFeature && alphaMul > 0.01f) {
+        DummyConfig &c = dummy->Get();
+        CRGBA origColor = c.corona.color;
+        c.corona.color.a = static_cast<unsigned char>(std::clamp(static_cast<float>(origColor.a) * alphaMul, 0.0f, 255.0f));
         if (c.corona.lightingType == eLightingMode::NonDirectional) {
             RenderUtil::RegisterCorona(pVeh, (reinterpret_cast<unsigned int>(pVeh) * 255) + 255 + id, c.position, c.corona.color, c.corona.size * szMul);
         } else {
             RenderUtil::RegisterCoronaDirectional(&dummy->Get(), c.rotation.angle, 180.0f, szMul, c.corona.lightingType == eLightingMode::Inversed, false);
         }
+        c.corona.color = origColor;
     }
 }
 
 void LightManager::RenderLight(CVehicle* pVeh, VehLightData& data, eMaterialType type, bool isOn, const std::string& texture, float sz, bool highlight, bool isDummyOk, bool materialsOnly) {
     if (!isOn || !data.bLightStates[type]) return;
 
+    data.bLightRenderedThisFrame[type] = true;
+    bool isAvailable = IsDummyAvailable(data, type);
+    float inertia = GetLightInertia(pVeh, data, type);
+
+    if (inertia > 0.01f) {
+        float step = (CTimer::ms_fTimeStep / 50.0f) / inertia;
+        data.fLightFactor[type] = std::min(1.0f, data.fLightFactor[type] + step);
+    } else {
+        data.fLightFactor[type] = 1.0f;
+    }
+
+    if (type == eMaterialType::HeadLightLeft) {
+        float target = (data.bLongLightsOn && isOn) ? 1.0f : 0.0f;
+        if (inertia > 0.01f) {
+            float hbStep = (CTimer::ms_fTimeStep / 50.0f) / inertia;
+            if (data.fHighBeamFactor < target) {
+                data.fHighBeamFactor = std::min(target, data.fHighBeamFactor + hbStep);
+            } else if (data.fHighBeamFactor > target) {
+                data.fHighBeamFactor = std::max(target, data.fHighBeamFactor - hbStep);
+            }
+        } else {
+            data.fHighBeamFactor = target;
+        }
+    }
+
+    float factor = data.fLightFactor[type];
     int id = static_cast<int>(type) * 1000;
     bool hasActiveDummy = false;
-    bool isAvailable = IsDummyAvailable(data, type);
 
     if (isAvailable) {
         for (auto& dummy : data.dummies[type]) {
@@ -176,20 +264,28 @@ void LightManager::RenderLight(CVehicle* pVeh, VehLightData& data, eMaterialType
             }
 
             float szMul = 1.0f;
-            if (highlight) {
+            if (type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) {
+                szMul = 1.0f + 2.0f * data.fHighBeamFactor;
+                if (highlight && !data.bLongLightsOn) {
+                    szMul = std::max(szMul, 3.00f);
+                }
+            } else if (highlight) {
                 szMul = (type == eMaterialType::TailLightLeft || type == eMaterialType::TailLightRight) ? 1.50f : 3.00f;
             }
-            EnableDummy((int)pVeh + 42 + id++, &dummy, pVeh, szMul);
+            EnableDummy((int)pVeh + 42 + id++, &dummy, pVeh, szMul, factor);
 
             // Skip front shadows on bike wheelie
             if (c.dummyPos == eDummyPos::Front && Util::IsVehicleDoingWheelie(pVeh)) {
                 continue;
             }
 
-            if (c.shadow.render) {
-                std::string tex = (c.shadow.texture == "") ? texture : c.shadow.texture;
+            if (c.shadow.render && factor > 0.01f) {
+                std::string tex = c.shadow.texture.empty() ? texture : c.shadow.texture;
+                if ((type == eMaterialType::HeadLightLeft || type == eMaterialType::HeadLightRight) && data.fHighBeamFactor > 0.3f) {
+                    tex = "headlight_long";
+                }
                 if (!tex.empty()) {
-                    RenderUtil::RegisterShadowDirectional(&dummy->Get(), tex, sz * c.shadow.size);
+                    RenderUtil::RegisterShadowDirectional(&dummy->Get(), tex, sz * c.shadow.size, factor);
                 }
             }
         }
@@ -300,4 +396,83 @@ bool LightManager::IsBraking(CVehicle* pVeh) {
     }
 
     return false;
+}
+
+const char* LightManager::GetLightGroupKey(eMaterialType type) {
+    switch (type) {
+    case eMaterialType::HeadLightLeft:
+    case eMaterialType::HeadLightRight:
+        return "headlights";
+    case eMaterialType::TailLightLeft:
+    case eMaterialType::TailLightRight:
+        return "taillights";
+    case eMaterialType::BrakeLightLeft:
+    case eMaterialType::BrakeLightRight:
+    case eMaterialType::NABrakeLightLeft:
+    case eMaterialType::NABrakeLightRight:
+        return "brakelights";
+    case eMaterialType::ReverseLightLeft:
+    case eMaterialType::ReverseLightRight:
+        return "reverselights";
+    case eMaterialType::IndicatorLightLeftFront:
+    case eMaterialType::IndicatorLightRightFront:
+    case eMaterialType::IndicatorLightLeftRear:
+    case eMaterialType::IndicatorLightRightRear:
+    case eMaterialType::IndicatorLightLeftMiddle:
+    case eMaterialType::IndicatorLightRightMiddle:
+        return "indicators";
+    case eMaterialType::FogLightLeft:
+    case eMaterialType::FogLightRight:
+        return "foglights";
+    default:
+        return nullptr;
+    }
+}
+
+const char* LightManager::GetLightSpecificKey(eMaterialType type) {
+    switch (type) {
+    case eMaterialType::HeadLightLeft: return "headlight_l";
+    case eMaterialType::HeadLightRight: return "headlight_r";
+    case eMaterialType::TailLightLeft: return "taillight_l";
+    case eMaterialType::TailLightRight: return "taillight_r";
+    case eMaterialType::BrakeLightLeft:
+    case eMaterialType::NABrakeLightLeft: return "brakelight_l";
+    case eMaterialType::BrakeLightRight:
+    case eMaterialType::NABrakeLightRight: return "brakelight_r";
+    case eMaterialType::ReverseLightLeft: return "reverselight_l";
+    case eMaterialType::ReverseLightRight: return "reverselight_r";
+    case eMaterialType::IndicatorLightLeftFront: return "indicator_lf";
+    case eMaterialType::IndicatorLightRightFront: return "indicator_rf";
+    case eMaterialType::IndicatorLightLeftRear: return "indicator_lr";
+    case eMaterialType::IndicatorLightRightRear: return "indicator_rr";
+    case eMaterialType::IndicatorLightLeftMiddle: return "indicator_lm";
+    case eMaterialType::IndicatorLightRightMiddle: return "indicator_rm";
+    case eMaterialType::FogLightLeft: return "foglight_l";
+    case eMaterialType::FogLightRight: return "foglight_r";
+    default: return nullptr;
+    }
+}
+
+float LightManager::GetLightInertia(CVehicle* pVeh, VehLightData& data, eMaterialType type) {
+    if (type >= 0 && type < eMaterialType::TotalMaterial && !data.dummies[type].empty()) {
+        float dInertia = data.dummies[type][0]->GetRef().inertia;
+        if (dInertia > 0.0f) return dInertia;
+    }
+
+    if (!pVeh) return 0.0f;
+    auto& json = DataMgr::Get(pVeh->m_nModelIndex);
+    if (!json.contains("lights")) return 0.0f;
+    auto& lights = json["lights"];
+
+    const char* specKey = GetLightSpecificKey(type);
+    if (specKey && lights.contains(specKey) && lights[specKey].contains("inertia")) {
+        return lights[specKey].value("inertia", 0.0f);
+    }
+
+    const char* grpKey = GetLightGroupKey(type);
+    if (grpKey && lights.contains(grpKey) && lights[grpKey].contains("inertia")) {
+        return lights[grpKey].value("inertia", 0.0f);
+    }
+
+    return lights.value("inertia", 0.0f);
 }

--- a/src/features/lights/manager.h
+++ b/src/features/lights/manager.h
@@ -29,10 +29,13 @@ public:
     static bool IsDummyAvailable(VehLightData& data, std::initializer_list<eMaterialType> types);
     static bool IsMaterialAvailable(CVehicle* pVeh, eMaterialType type);
     static bool IsMaterialAvailable(CVehicle* pVeh, std::initializer_list<eMaterialType> types);
-    static void EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMul);
+    static void EnableDummy(int id, VehicleDummy *dummy, CVehicle *pVeh, float szMul, float alphaMul = 1.0f);
     static void Reload(CVehicle* pVeh);
     static bool GetLightState(CVehicle* pVeh, eMaterialType lightId) { return m_VehData.Get(pVeh).bLightStates[lightId]; }
     static void SetLightState(CVehicle* pVeh, eMaterialType lightId, bool state) { m_VehData.Get(pVeh).bLightStates[lightId] = state; }
     static bool IsIndicatorOn(CVehicle* pVeh);
     static bool IsBraking(CVehicle* pVeh);
+    static const char* GetLightGroupKey(eMaterialType type);
+    static const char* GetLightSpecificKey(eMaterialType type);
+    static float GetLightInertia(CVehicle* pVeh, VehLightData& data, eMaterialType type);
 };

--- a/src/utils/modelinfomgr.cpp
+++ b/src/utils/modelinfomgr.cpp
@@ -15,6 +15,7 @@
 #include "features/dirtfx.h"
 #include "features/plate.h"
 #include "features/remap.h"
+#include "features/lights/manager.h"
 #include "defines.h"
 #include "utils/meevents.h"
 #include "utils/texmgr.h"
@@ -339,6 +340,16 @@ RpMaterial *ModelInfoMgr::SetEditableMaterialsCB(RpMaterial *material,
     pColor->blue = matCol.on.b;
 
     if (lightOn) {
+      float factor = 1.0f;
+      if (iLightIndex != eMaterialType::SirenLight &&
+          iLightIndex != eMaterialType::SpotLight &&
+          iLightIndex < eMaterialType::EngineOnLed &&
+          iLightIndex >= 0 && iLightIndex < eMaterialType::TotalMaterial) {
+        VehLightData &lData = LightManager::m_VehData.Get(pCurVeh);
+        if (lData.fLightFactor[iLightIndex] > 0.001f) {
+          factor = lData.fLightFactor[iLightIndex];
+        }
+      }
       m_RestoreEntries.push_back({&material->texture, material->texture});
 
       if (material->texture) {
@@ -356,11 +367,7 @@ RpMaterial *ModelInfoMgr::SetEditableMaterialsCB(RpMaterial *material,
         }
       }
       m_SurfPropsRestoreEntries.push_back({material, material->surfaceProps});
-      material->surfaceProps = GetLightSurfaceProps();
-    } else {
-      pColor->red = matCol.off.r;
-      pColor->green = matCol.off.g;
-      pColor->blue = matCol.off.b;
+      material->surfaceProps = GetLightSurfaceProps(factor);
     }
   } else {
     CRGBA col = {255, 255, 255, 255};

--- a/src/utils/render.cpp
+++ b/src/utils/render.cpp
@@ -446,7 +446,7 @@ static int GetShadowIntensity(eMaterialType lightType)
     return std::clamp(intensity, 0, 255);
 }
 
-void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std::string &shadwTexName, float shdwSz)
+void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std::string &shadwTexName, float shdwSz, float alphaMul)
 {
     EnsureConfigLoaded();
     const float SHDW_SZ_MUL = 2.0f;
@@ -514,11 +514,14 @@ void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std
         rightDir = -rightDir;
     }
 
-    // Push shadow forward along light direction
-    CVector shdwCenter = worldPos + lightDir * (shdwSz * SHDW_SZ_MUL + 0.2f);
+    // Scale shadow size/thickness with inertia factor so it expands/contracts naturally
+    float currentShdwSz = shdwSz * (0.35f + 0.65f * std::clamp(alphaMul, 0.0f, 1.0f));
 
-    CVector2D shdwFront(lightDir.x * (shdwSz * SHDW_SZ_MUL), lightDir.y * (shdwSz * SHDW_SZ_MUL));
-    CVector2D shdwSide(rightDir.x * shdwSz, rightDir.y * shdwSz);
+    // Push shadow forward along light direction
+    CVector shdwCenter = worldPos + lightDir * (currentShdwSz * SHDW_SZ_MUL + 0.2f);
+
+    CVector2D shdwFront(lightDir.x * (currentShdwSz * SHDW_SZ_MUL), lightDir.y * (currentShdwSz * SHDW_SZ_MUL));
+    CVector2D shdwSide(rightDir.x * currentShdwSz, rightDir.y * currentShdwSz);
 
     RwTexture *pTex = TextureMgr::Get(shadwTexName);
     if (!pTex)
@@ -529,11 +532,12 @@ void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std
     CVector shdwPos(shdwCenter.x, shdwCenter.y, pConfig->pVeh->GetPosition().z + 2.0f);
 
     // Fade towards the cutoff so distant shadows don't pop in and out
-    float alphaMul = 1.0f;
+    float distAlpha = 1.0f;
     if (distToCam > SHDW_FADE_DIST)
     {
-        alphaMul = (SHDW_MAX_DIST - distToCam) / (SHDW_MAX_DIST - SHDW_FADE_DIST);
+        distAlpha = (SHDW_MAX_DIST - distToCam) / (SHDW_MAX_DIST - SHDW_FADE_DIST);
     }
+    float finalAlpha = distAlpha * std::clamp(alphaMul, 0.0f, 1.0f);
 
     float shadowIntensityFactor = static_cast<float>(GetShadowIntensity(pConfig->lightType)) / 255.0f;
     unsigned char r = static_cast<unsigned char>(pConfig->shadow.color.r * shadowIntensityFactor);
@@ -546,7 +550,7 @@ void RenderUtil::RegisterShadowDirectional(const DummyConfig *pConfig, const std
         &shdwPos,
         shdwFront.x, shdwFront.y,
         shdwSide.x, shdwSide.y,
-        static_cast<short>(255 * alphaMul),
+        static_cast<short>(255 * finalAlpha),
         r,
         g,
         b,

--- a/src/utils/render.h
+++ b/src/utils/render.h
@@ -19,6 +19,6 @@ public:
     static void RegisterPointLight(const DummyConfig *pConfig, CRGBA col, float radius, bool isSpotlight = true);
     static void RegisterCoronaDirectional(const DummyConfig *pConfig, float angle, float radius, float szMul = 1.0f, bool inversed = false, bool skipCheck = true);
     static void RegisterShadow(CEntity *pEntity, CVector position, CRGBA col, float angle, eDummyPos dummyPos, const std::string &shadwTexName, CVector2D shdwSz = {1.0f, 1.0f}, CVector2D shdwOffset = {0.0f, 0.0f}, RwTexture *pTexture = nullptr);
-    static void RegisterShadowDirectional(const DummyConfig *pConfig, const std::string &shadwTexName, float shdwSz);
+    static void RegisterShadowDirectional(const DummyConfig *pConfig, const std::string &shadwTexName, float shdwSz, float alphaMul = 1.0f);
     static void ReloadConfig();
 };


### PR DESCRIPTION
### Summary

Adds realistic per-vehicle bulb filament inertia (smooth fade-in and fade-out transitions) for all vehicle light types, with full support for dynamic shadow scaling, custom material tint retention, and smooth high-beam corona transitions.

---

### Features & Improvements

1. **Per-Vehicle & Per-Light Inertia (`DummyConfig::inertia` & JSONC):**
   - Configurable per dummy (`inertia` field in per-light JSON sections), with graceful fallback to group keys (`headlights`, `taillights`, `brakelights`, `reverselights`, `indicators`, `foglights`) and global vehicle fallback `lights["inertia"]`.
   - Delta-time based interpolation (`CTimer::ms_fTimeStep / 50.0f / inertia`) ensures identical real-time duration regardless of framerate (30 FPS, 60 FPS, or uncapped).
   - Zero overhead on vehicles without inertia (`inertia <= 0.01f`): factors set instantly to `1.0f` on activation and `0.0f` on deactivation, completely bypassing fade rendering.

2. **Full Light Material Dimming & Color Retention:**
   - Smoothly dims material `surfaceProps.ambient` and `surfaceProps.diffuse` scaled by `fLightFactor`, so lamp geometry realistically fades out instead of abruptly switching off.
   - Preserves custom lamp tint (e.g. vintage halogen yellow, amber indicator glass) across both on and off states in `SetEditableMaterialsCB`, eliminating the jarring yellow-to-white pop when turning off lights.

3. **Dynamic Directional Shadow Scaling:**
   - `RenderUtil::RegisterShadowDirectional` now accepts `alphaMul`, scaling both shadow opacity (`finalAlpha`) and physical shadow cone dimensions (`currentShdwSz = shdwSz * (0.35f + 0.65f * alphaMul)`).
   - Light cones smoothly expand outward on activation and retract gracefully during fade-out.
   - Automatically inherits custom corona RGB to shadow color when no explicit `shadow.color` is configured, preventing custom-colored headlights/reverse lights from casting default white ground shadows.

4. **Smooth High-Beam (Long Lights) Transitions:**
   - `fHighBeamFactor` interpolates smoothly between low-beam (`1.0x`) and high-beam (`3.0x`) corona size.
   - When turning headlights off while high beams are active, high-beam state is preserved throughout the inertia fade-out rather than abruptly snapping down to low-beam size before fading.