### PR TITLE
fix(lights): apply taillight shadow size and intensity to STT, brake and NABrake lights

### DIFF
--- a/src/features/lights/components/brake_light.cpp
+++ b/src/features/lights/components/brake_light.cpp
@@ -21,7 +21,10 @@ bool BrakeLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, cons
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.dummyPos = eDummyPos::Rear;
         c.lightType = STR_FOUND(name, "_l") ? eMaterialType::BrakeLightLeft : eMaterialType::BrakeLightRight;
-        c.corona.color = c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gGlobalCoronaIntensity)};
+        c.corona.size = LightsConfig::Get().gfTailLightCoronaSize;
+        c.corona.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightCoronaIntensity)};
+        c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightShadowIntensity)};
+        c.shadow.size = LightsConfig::Get().gfTailLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
         data.dummies[c.lightType].push_back(VehicleDummy(c));
         return true;

--- a/src/features/lights/components/nabrake_light.cpp
+++ b/src/features/lights/components/nabrake_light.cpp
@@ -21,7 +21,10 @@ bool NABrakeLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, co
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.lightType = (d == "L") ? eMaterialType::NABrakeLightLeft : eMaterialType::NABrakeLightRight;
         c.dummyPos = eDummyPos::Rear;
-        c.corona.color = c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gGlobalCoronaIntensity)};
+        c.corona.size = LightsConfig::Get().gfTailLightCoronaSize;
+        c.corona.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightCoronaIntensity)};
+        c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightShadowIntensity)};
+        c.shadow.size = LightsConfig::Get().gfTailLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
         data.dummies[c.lightType].push_back(VehicleDummy(c));
         return true;

--- a/src/features/lights/components/stt_light.cpp
+++ b/src/features/lights/components/stt_light.cpp
@@ -21,7 +21,10 @@ bool STTLightComponent::TryRegisterDummy(CVehicle* pVeh, RwFrame* pFrame, const 
         DummyConfig c = LightManager::CreateBaseConfig(pVeh, pFrame);
         c.lightType = (d == "L") ? eMaterialType::STTLightLeft : eMaterialType::STTLightRight;
         c.dummyPos = eDummyPos::Rear;
-        c.corona.color = c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gGlobalCoronaIntensity)};
+        c.corona.size = LightsConfig::Get().gfTailLightCoronaSize;
+        c.corona.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightCoronaIntensity)};
+        c.shadow.color = {240, 0, 0, static_cast<unsigned char>(LightsConfig::Get().gTailLightShadowIntensity)};
+        c.shadow.size = LightsConfig::Get().gfTailLightShadowSize;
         c.corona.lightingType = eLightingMode::Directional;
         data.dummies[c.lightType].push_back(VehicleDummy(c));
         return true;

--- a/src/utils/render.cpp
+++ b/src/utils/render.cpp
@@ -438,6 +438,12 @@ static int GetShadowIntensity(eMaterialType lightType)
         break;
     case eMaterialType::TailLightLeft:
     case eMaterialType::TailLightRight:
+    case eMaterialType::STTLightLeft:
+    case eMaterialType::STTLightRight:
+    case eMaterialType::BrakeLightLeft:
+    case eMaterialType::BrakeLightRight:
+    case eMaterialType::NABrakeLightLeft:
+    case eMaterialType::NABrakeLightRight:
         intensity = gnTailLightShadowIntensity;
         break;
     default:


### PR DESCRIPTION
### Summary
- Applies `TailLightShadowSize` and `TailLightShadowIntensity` configuration values to STT (Sequential Tail Turn), dedicated brake (`breakl`), and NABrake (`nabrakelight`) light dummies upon registration.
- Adds `STTLightLeft/Right`, `BrakeLightLeft/Right`, and `NABrakeLightLeft/Right` to `GetShadowIntensity()` in `render.cpp` so they consistently resolve to `gnTailLightShadowIntensity`.
- Resolves an issue where setting `TailLightShadowSize = 0` in `ModelExtras.ini` disabled shadows on standard vehicles but left projected ground shadows active on vehicles with STT/NABrake setups.