### PR TITLE
fix(lights): allow fog lights to render independently when FoglightTiedToHeadlight is false

### DIFF
--- a/src/features/leds.cpp
+++ b/src/features/leds.cpp
@@ -104,11 +104,10 @@ void DashboardLEDs::Init()
 		}
 
 		const auto& data = Lights::GetVehicleData(pControlVeh);
-		static bool foglightTiedtoHeadlight = gConfig.ReadBoolean("TWEAKS", "FoglightTiedToHeadlight", true);
 		bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pControlVeh))) && !CarUtil::IsLightsForcedOff(pControlVeh);
 		bool isFoggy = Util::IsFoggy();
-		bool shouldShowFog = isFoggy || !foglightTiedtoHeadlight || isHeadlightsActive;
-		bool isFogLightOn = (data.bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pControlVeh);
+		bool shouldShowFog = isFoggy || !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
+		bool isFogLightOn = (data.bFogLightsOn || isFoggy) && (!LightsConfig::Get().bFoglightTiedToHeadlight || !CarUtil::IsLightsForcedOff(pControlVeh));
 		if (isFogLightOn && shouldShowFog) {
 			EnableLED(pControlVeh, eMaterialType::FogLightLed);
 		}

--- a/src/features/lights/components/fog_light.cpp
+++ b/src/features/lights/components/fog_light.cpp
@@ -47,7 +47,7 @@ void FogLightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehLi
     bool isHeadlightsActive = (pControlVeh->bLightsOn || CarUtil::IsLightsForcedOn(pControlVeh) || Util::IsNightTime()) && !CarUtil::IsLightsForcedOff(pControlVeh);
     bool isFoggy = Util::IsFoggy();
     bool shouldRenderFog = isFoggy || !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsActive;
-    bool isFogLightOn = (data.bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pControlVeh);
+    bool isFogLightOn = (data.bFogLightsOn || isFoggy) && (!LightsConfig::Get().bFoglightTiedToHeadlight || !CarUtil::IsLightsForcedOff(pControlVeh));
 
     if (!isFogLightOn || !shouldRenderFog) return;
     bool isFogOk = !Util::IsPanelDamaged(pControlVeh, ePanels::BUMP_FRONT);
@@ -59,7 +59,7 @@ void FogLightComponent::ProcessPointLights(CVehicle* pVeh, VehLightData& data) {
     bool isHeadlightsOn = (pVeh->bLightsOn || CarUtil::IsLightsForcedOn(pVeh) || (Util::IsNightTime() && !Util::IsEngineOff(pVeh))) && !CarUtil::IsLightsForcedOff(pVeh);
     bool isFoggy = Util::IsFoggy();
     bool shouldRenderFog = isFoggy || !LightsConfig::Get().bFoglightTiedToHeadlight || isHeadlightsOn;
-    bool isFogLightOn = (data.bFogLightsOn || isFoggy) && !CarUtil::IsLightsForcedOff(pVeh);
+    bool isFogLightOn = (data.bFogLightsOn || isFoggy) && (!LightsConfig::Get().bFoglightTiedToHeadlight || !CarUtil::IsLightsForcedOff(pVeh));
 
     if (isFogLightOn && shouldRenderFog) {
         for (eMaterialType type : {eMaterialType::FogLightLeft, eMaterialType::FogLightRight}) {


### PR DESCRIPTION
### Summary
- Allows fog lights and their point lights to render independently when `FoglightTiedToHeadlight = 0`, even when headlights are inactive or forced off.
- Updates `FogLightComponent::Render` and `FogLightComponent::ProcessPointLights` to ensure `IsLightsForcedOff` check is only enforced when `bFoglightTiedToHeadlight` is enabled.
- Synchronizes dashboard fog light LED logic in `leds.cpp` with `LightsConfig::Get().bFoglightTiedToHeadlight`.