### PR TITLE
fix(samp): patch vehicle lights reset and handle daytime light states when SA-MP is loaded

### DIFF
--- a/src/features/lights/components/headlight.cpp
+++ b/src/features/lights/components/headlight.cpp
@@ -142,6 +142,8 @@ void HeadlightComponent::Render(CVehicle* pControlVeh, CVehicle* pTowedVeh, VehL
     bool highlight = isFoggy || data.bLongLightsOn;
 
     if (isHeadlightLeftOk || isHeadlightRightOk) {
+        pControlVeh->m_renderLights.m_bLeftFront = isHeadlightLeftOk;
+        pControlVeh->m_renderLights.m_bRightFront = isHeadlightRightOk;
         if (isHeadlightLeftOk) {
             LightManager::RenderLights(pControlVeh, pTowedVeh, data, eMaterialType::HeadLightLeft, true, shadow ? texName : "", LightsConfig::Get().headlightSz, highlight, true, bTickRegistered);
         }

--- a/src/features/lights/lights.cpp
+++ b/src/features/lights/lights.cpp
@@ -5,6 +5,7 @@
 #include "utils/meevents.h"
 #include "utils/datamgr.h"
 #include "ModelExtrasAPI.h"
+#include "utils/samp.h"
 
 float gfGlobalCoronaSize = 0.3f;
 int gGlobalCoronaIntensity = 80;
@@ -26,6 +27,14 @@ void Lights::Init() {
 	// CVehicle::DoHeadLightEffect
 	patch::SetUChar(0x6E0CF8, 0);
 	patch::SetUChar(0x6E0DEE, 0);
+
+	// CVehicle::DoVehicleLights (native headlight coronas)
+	patch::SetUChar(0x6E2193, 0);
+	patch::SetUChar(0x6E228B, 0);
+	patch::SetUChar(0x6E2532, 0);
+	patch::SetUChar(0x6E2627, 0);
+
+	SAMP::PatchVehicleLights();
 
 	// NOP CVehicle::DoHeadLightBeam
 	if (!gConfig.ReadBoolean("LIGHTS", "HeadLightBeams", gConfig.ReadBoolean("TWEAKS", "HeadLightBeams", true)))

--- a/src/utils/samp.cpp
+++ b/src/utils/samp.cpp
@@ -164,4 +164,32 @@ namespace SAMP
         const char *text = FindPlateText(pool, pGameVeh);
         return text ? SanitizeAndFormatPlateText(text) : "";
     }
+
+    void PatchVehicleLights()
+    {
+        if (!IsPresent()) return;
+
+        static bool s_patched = false;
+        if (s_patched) return;
+        s_patched = true;
+
+        // Apply the exact patches that SA-MP applies across all versions (0.3.7-R1, R3, R5, 0.3.DL)
+        // inside CVehicle::DoVehicleLights when ManualVehicleEngineAndLights() is enabled.
+        patch::Nop(0x6E1BA0, 6);
+        patch::Nop(0x6E1BB1, 6);
+        patch::Nop(0x6E1BD2, 7);
+
+        // SA-MP replaces the driver/clock check at 0x6E1BE3 with a test of bLightsOn (bit 6 of 0x428):
+        // 0x6E1BE3: NOP NOP
+        // 0x6E1BE5: mov al, byte ptr [esi + 0x428]
+        // 0x6E1BEB: test al, 0x40
+        // 0x6E1BED: je 0x6E1C17 (+0x28)
+        // 0x6E1BEF..0x6E1C07: NOPs (25 bytes)
+        patch::Nop(0x6E1BE3, 0x25);
+        patch::SetRaw(0x6E1BE5, (void *)"\x8A\x86\x28\x04\x00\x00\xA8\x40\x74\x28", 10);
+
+        patch::Nop(0x6E1C38, 8);
+        patch::Nop(0x6E1D98, 0xF);
+        patch::Nop(0x6E1DBC, 8);
+    }
 }

--- a/src/utils/samp.h
+++ b/src/utils/samp.h
@@ -14,4 +14,12 @@ namespace SAMP
     // Retrieves and formats the custom license plate text for the given vehicle.
     // Returns empty string if not in SA-MP, vehicle not found in pool, or default plate ("XYZSR998").
     std::string GetVehiclePlateText(CVehicle *pGameVeh);
+
+    // Applies SA-MP vehicle light patches to GTA SA if SA-MP is loaded.
+    // On SA-MP servers that do not call ManualVehicleEngineAndLights(),
+    // SA-MP skips NOPing GTA SA's CVehicle::DoVehicleLights daytime reset logic.
+    // This causes GTA SA to continuously clear bLightsOn every frame in daytime,
+    // conflicting with SA-MP sync packets and producing rapid headlight flickering
+    // as well as preventing the local player's /lights command from working.
+    void PatchVehicleLights();
 }


### PR DESCRIPTION
### Summary
- Applies SA-MP vehicle light patches to GTA SA's `CVehicle::DoVehicleLights` when SA-MP is loaded (`0.3.7-R1`, `R3`, `R5`, `0.3.DL`).
- Replaces GTA SA's hardcoded daytime `bLightsOn` reset and clock check with SA-MP's native test of `bLightsOn` (`0x6E1BE5`: `mov al, [esi+0x428] / test al, 0x40 / je 0x6E1C17`), resolving rapid headlight flickering on servers without `ManualVehicleEngineAndLights()` while ensuring lights and beams stay off during daytime on time-based servers (e.g. MovieServer).
- Zeroes out the alpha operands for native headlight reflection coronas inside `CVehicle::DoVehicleLights` (`0x6E2193`, `0x6E228B`, `0x6E2532`, `0x6E2627`), preventing duplicate or stuck native 2D coronas from rendering.
- Synchronizes `m_renderLights.m_bLeftFront` and `m_bRightFront` in `HeadlightComponent::Render()` to ensure vanilla ground beams (`HeadLightBeams`) project cleanly at night or when forced on, and remain off during daytime.